### PR TITLE
界面字号档位、自适应布局，全屏进出更丝滑

### DIFF
--- a/native/App/Info.plist
+++ b/native/App/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.1</string>
+	<string>2.2.0</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>15.0</string>
 	<key>NSHighResolutionCapable</key>

--- a/native/Sources/LeetCodeAssistant/Design/DesignTokens.swift
+++ b/native/Sources/LeetCodeAssistant/Design/DesignTokens.swift
@@ -2,24 +2,32 @@ import SwiftUI
 
 enum AppDesign {
     /// 字体阶梯（G-T1）：全 App 只有这一组字号，View 层不再新增 `.system(size:)`。
-    /// 尺寸集合收敛为 26 / 22 / 17 / 15 / 13 / 12 / 11 七档，无半点字号。
+    /// 基准尺寸集合收敛为 26 / 22 / 17 / 15 / 13 / 12 / 11 七档，无半点字号。
+    ///
+    /// 每档都乘 `scale`（「设置 ▸ 外观 ▸ 界面字号」）。所以这里是**计算属性**而不是 `static let`：
+    /// `static let` 在进程启动时就定死了，换档位不会变；计算属性在 View 的 body 里求值，
+    /// 那次对 `InterfaceMetrics.shared` 的读取会被 SwiftUI 登记成依赖，改档位即时重绘。
+    @MainActor
     enum Typography {
-        static let display = Font.system(size: 26, weight: .semibold)
-        static let pageTitle = Font.system(size: 22, weight: .semibold)
-        static let metricValue = Font.system(size: 22, weight: .semibold).monospacedDigit()
-        static let sectionTitle = Font.system(size: 17, weight: .semibold)
-        static let rowTitle = Font.system(size: 15, weight: .medium)
+        /// 当前界面字号倍率，见 `InterfaceMetrics`。
+        static var scale: CGFloat { InterfaceMetrics.shared.scale }
+
+        static var display: Font { .system(size: 26 * scale, weight: .semibold) }
+        static var pageTitle: Font { .system(size: 22 * scale, weight: .semibold) }
+        static var metricValue: Font { .system(size: 22 * scale, weight: .semibold).monospacedDigit() }
+        static var sectionTitle: Font { .system(size: 17 * scale, weight: .semibold) }
+        static var rowTitle: Font { .system(size: 15 * scale, weight: .medium) }
         /// 标题行的加重版：窗口标题、侧栏品牌行等"页面身份"文字。
-        static let rowTitleEmphasis = Font.system(size: 15, weight: .semibold)
-        static let body = Font.system(size: 13)
-        static let bodyEmphasis = Font.system(size: 13, weight: .medium)
-        static let aux = Font.system(size: 12)
-        static let auxEmphasis = Font.system(size: 12, weight: .medium)
-        static let micro = Font.system(size: 11)
-        static let mono = Font.system(size: 12, design: .monospaced)
+        static var rowTitleEmphasis: Font { .system(size: 15 * scale, weight: .semibold) }
+        static var body: Font { .system(size: 13 * scale) }
+        static var bodyEmphasis: Font { .system(size: 13 * scale, weight: .medium) }
+        static var aux: Font { .system(size: 12 * scale) }
+        static var auxEmphasis: Font { .system(size: 12 * scale, weight: .medium) }
+        static var micro: Font { .system(size: 11 * scale) }
+        static var mono: Font { .system(size: 12 * scale, design: .monospaced) }
         /// 行内 SF Symbol 的统一口径（G-T5）。
-        static let icon = Font.system(size: 15)
-        static let iconCompact = Font.system(size: 13, weight: .medium)
+        static var icon: Font { .system(size: 15 * scale) }
+        static var iconCompact: Font { .system(size: 13 * scale, weight: .medium) }
     }
 
     enum Spacing {
@@ -42,56 +50,88 @@ enum AppDesign {
         static let composer: CGFloat = 22
     }
 
+    /// 尺寸阶梯。
+    ///
+    /// 分两类：
+    /// **窗口 chrome**（列头高度、红绿灯内缩、标题栏）是死数——它们要和系统画的东西对齐，
+    /// 跟着界面字号一起变会把红绿灯和列头的中线错开。
+    /// **装文字的那些**（列宽、行高、输入框）跟着 `Typography.scale` 一起放大：
+    /// 只放大字不放大列，侧栏标题只会截得更狠——"字大了反而更难看"就是这么来的。
+    @MainActor
     enum Size {
+        /// 装文字的尺寸统一走它。取整到整数点，避免半点宽度在分栏线上抖。
+        private static func scaled(_ value: CGFloat) -> CGFloat {
+            (value * AppDesign.Typography.scale).rounded()
+        }
+
+        // MARK: 窗口 chrome —— 不缩放
+
         /// 列头部高度。红绿灯与列头同一条中线——但不是列头去迁就系统，
         /// 而是 `WindowTitlebarLayout` 把红绿灯挪到列头这条线上来。
         /// 不要用 AppKit accessory 加高标题栏：实测按钮纹丝不动，那一层还会吃掉整行点击。
-        static let columnHeader: CGFloat = 40
+        nonisolated static let columnHeader: CGFloat = 40
         /// 列头到窗口顶边的留白。窗口态谁都不许贴着顶边框，红绿灯也一样。
         /// 4pt：红绿灯中线落到 24pt（系统默认 16pt），比 Codex 略松一点点就够，
         /// 再多整条列头就和窗口脱节了。
-        static let headerTopMargin: CGFloat = 4
+        nonisolated static let headerTopMargin: CGFloat = 4
         /// 系统默认标题栏高度。
-        static let windowTitlebarInset: CGFloat = 28
+        nonisolated static let windowTitlebarInset: CGFloat = 28
         /// 红绿灯自己的左内缩。系统默认 9pt，贴边太紧，往右挪 3pt 和顶部留白配平。
-        static let trafficLightLeadingInset: CGFloat = 14
+        nonisolated static let trafficLightLeadingInset: CGFloat = 14
         /// 红绿灯占位宽度：最左列头从这里之后开始排（三颗按钮 69pt + 一档间距）。
-        static let trafficLightInset: CGFloat = 81
-        static let sidebarMin: CGFloat = 218
-        static let sidebarIdeal: CGFloat = 256
-        static let sidebarMax: CGFloat = 310
-        static let compactRow: CGFloat = 34
-        static let listRow: CGFloat = 44
-        static let contextPanel: CGFloat = 312
-        static let contextPanelMinimum: CGFloat = 292
-        static let contextPanelMaximum: CGFloat = 324
-        static let inspectorMin: CGFloat = 380
-        static let inspectorIdeal: CGFloat = 460
+        nonisolated static let trafficLightInset: CGFloat = 81
+        /// 标题栏那一带的控件槽位。跟着 `columnHeader` 走，所以也不缩放：
+        /// 它放大而列头不放大，控件就会顶出那条 40pt 的可视带。
+        nonisolated static let toolbarControl: CGFloat = 28
+        /// 工具条内竖分隔线高度。
+        nonisolated static let toolbarSeparator: CGFloat = 18
+        nonisolated static let rail: CGFloat = 56
+
+        // MARK: 装文字的尺寸 —— 跟随界面字号
+
+        /// 页内列表列（题库列表 / 复习队列 / 算法模板 / 计划日历这类"二级侧栏"）的可拖区间。
+        /// 和第一列不是一回事：它在详情窗格内部，窗口拉宽时得能跟着拉宽，
+        /// 否则 1920 的窗口里它还是 268pt，多出来的宽度全堆给右边。
+        static var paneListMin: CGFloat { scaled(240) }
+        static var paneListMax: CGFloat { scaled(520) }
+        static var sidebarMin: CGFloat { scaled(218) }
+        static var sidebarIdeal: CGFloat { scaled(256) }
+        static var sidebarMax: CGFloat { scaled(310) }
+        static var compactRow: CGFloat { scaled(34) }
+        static var listRow: CGFloat { scaled(44) }
+        static var contextPanel: CGFloat { scaled(312) }
+        static var contextPanelMinimum: CGFloat { scaled(292) }
+        static var contextPanelMaximum: CGFloat { scaled(324) }
+        static var inspectorMin: CGFloat { scaled(380) }
+        static var inspectorIdeal: CGFloat { scaled(460) }
         /// 第三列的**兜底**上限，真正的上限按窗口算（`WorkspaceSplitLayoutPolicy.inspectorMax(total:sidebarWidth:)`）：
         /// 写死 620 的话，屏幕再大第三列也只能到 620pt，浏览器一开就挤。
-        static let inspectorMax: CGFloat = 620
+        static var inspectorMax: CGFloat { scaled(620) }
         /// 中间列最小宽。**自动布局**用它：窗口窄到三列放不下时，应用自己收侧栏。
-        static let primaryMinimum: CGFloat = 620
+        static var primaryMinimum: CGFloat { scaled(620) }
         /// 手动拖分栏线时中间列的下限。比自动断点低——你自己把它压窄是明确意图，
         /// 和"窗口太小、应用替你决定"是两回事。第三列能拉多宽由它决定。
-        static let primaryDragMinimum: CGFloat = 420
-        static let contentReadable: CGFloat = 780
+        static var primaryDragMinimum: CGFloat { scaled(420) }
+        static var contentReadable: CGFloat { scaled(780) }
+        /// 设置页表单列宽。全 App 只有这一个值：页头当年写死 740、账户页内容却用 980，
+        /// 于是那一页的标题和卡片左缘对不齐。
+        static var settingsColumn: CGFloat { scaled(740) }
         /// 对话正文 / 标题 / 输入框共用的内容列宽上限。
         /// 1100 而不是原来的 820：820 时正文在宽列里居中，左边会空出一大条，
         /// 和贴着列左缘的问题刻度条隔着一片空白。让正文往外延展，那条空白就没了。
-        static let contentColumnMaximum: CGFloat = 1_100
-        static let composerMinimumHeight: CGFloat = 50
-        static let toolbarControl: CGFloat = 28
-        static let rail: CGFloat = 56
+        static var contentColumnMaximum: CGFloat { scaled(1_100) }
+        /// 仪表盘类页面（学习洞察这种卡片网格）的版心上限。
+        /// 比正文列宽得多：卡片网格不是要读的长句子，没有"每行别超过 N 个字"的约束，
+        /// 钉在 1100 的结果就是 1920 宽的窗口里两侧各空 400pt，内容缩成中间一座孤岛。
+        static var dashboardColumnMaximum: CGFloat { scaled(1_600) }
+        static var composerMinimumHeight: CGFloat { scaled(50) }
         /// 页面头两档高度（G-T3）：列表类 44、带主按钮 54。
-        static let pageHeader: CGFloat = 44
-        static let pageHeaderProminent: CGFloat = 54
-        /// 工具条内竖分隔线高度。
-        static let toolbarSeparator: CGFloat = 18
+        static var pageHeader: CGFloat { scaled(44) }
+        static var pageHeaderProminent: CGFloat { scaled(54) }
         /// 内联输入框统一高度。
-        static let fieldHeight: CGFloat = 30
+        static var fieldHeight: CGFloat { scaled(30) }
         /// 行内图标槽位宽度，保证同列图标左缘对齐。
-        static let iconSlot: CGFloat = 24
+        static var iconSlot: CGFloat { scaled(24) }
     }
 
     enum Motion {

--- a/native/Sources/LeetCodeAssistant/Design/InterfaceMetrics.swift
+++ b/native/Sources/LeetCodeAssistant/Design/InterfaceMetrics.swift
@@ -1,0 +1,142 @@
+import SwiftUI
+
+/// 界面字号档位。
+///
+/// **为什么需要它**：`Font.system(size:)` 在 macOS 上是固定 pt——既不跟系统文字尺寸走，
+/// 也没有 App 级缩放。界面按点排版，屏幕越大分辨率越高，同一个 13pt 在物理上就越小，
+/// 于是"换了大屏，字反而更小"。整套 `AppDesign.Typography` 与 `Font.appScaled(size:)`
+/// 都乘上这里的倍率，用户在「设置 ▸ 外观」里选一次就全局生效。
+///
+/// **为什么是 `@Observable` 而不是一个全局常量**：SwiftUI 的观察按"读取发生的时机"登记，
+/// `AppDesign.Typography.body` 是在 View 的 body 求值时才去读 `shared.fontScale` 的，
+/// 这次读取正好落在 body 的观察范围内。所以换档位时，只有真正用了字体 token 的视图重绘——
+/// 不必给根视图挂 `.id()` 把整棵树连同 WKWebView 一起重建（那会让浏览器列的页面全部重新加载）。
+@MainActor
+@Observable
+final class InterfaceMetrics {
+    static let shared = InterfaceMetrics()
+
+    enum FontScale: String, CaseIterable, Identifiable, Sendable {
+        case compact
+        case standard
+        case large
+        case followDisplay
+
+        var id: String { rawValue }
+
+        /// 固定档的倍率。档距取 ~1.12：再密就分不出来，再疏则大一档会把三列布局挤到断点以下。
+        /// `followDisplay` 不在这里取值——它按屏幕现算，见 `InterfaceMetrics.scale`。
+        var multiplier: CGFloat {
+            switch self {
+            case .compact: 0.92
+            case .standard: 1
+            case .large: 1.12
+            case .followDisplay: 1
+            }
+        }
+
+        var title: String {
+            switch self {
+            case .compact: "紧凑"
+            case .standard: "标准"
+            case .large: "较大"
+            case .followDisplay: "跟随屏幕"
+            }
+        }
+    }
+
+    private static let storageKey = "interfaceFontScale"
+
+    /// 用户在设置里选的档位，作用在自动缩放**之上**（相对调整，不是绝对字号）。
+    var fontScale: FontScale {
+        didSet {
+            guard fontScale != oldValue else { return }
+            UserDefaults.standard.set(fontScale.rawValue, forKey: Self.storageKey)
+        }
+    }
+
+    /// 按当前屏幕算出来的自动缩放。
+    private(set) var displayScale: CGFloat = 1
+
+    /// 实际生效的倍率。
+    ///
+    /// **默认不跟屏幕走**：按屏幕自动缩放只在用户明确选了「跟随屏幕」时才生效。
+    /// 实测把 Electron 那条曲线原样搬过来，1920×1080 的外接屏上会算出 1.38×——
+    /// 正文 13pt 变成 18pt，对原生版这套本来就更密的排版来说太冲了，
+    /// 而且列宽没跟着变，侧栏标题反而截得更狠。所以它是一个选项，不是默认值。
+    var scale: CGFloat {
+        fontScale == .followDisplay ? displayScale : fontScale.multiplier
+    }
+
+    /// 屏幕自动缩放的口径，**照搬 Electron 1.x 客户端的 `src/platform/display-profile.js`**：
+    /// 以 1800pt 的工作区对角线为基准（约等于 1440×900 的笔记本屏），
+    /// 每超出 1% 就多放大 1.7%，封顶 1.5×。
+    ///
+    /// 为什么要照搬而不是重新拍一组数：老客户端在这台机器的外接屏（1920×1080 @1x，
+    /// 对角线约 2200）上算出来是 ~1.37×，用户已经习惯了那个观感；
+    /// 原生版重写时把这套整个丢了，同一块屏上字就"忽然变小了"。
+    private static let baseWorkAreaDiagonal: CGFloat = 1_800
+    /// 封顶从 Electron 的 1.5 收到 1.25：原生版的字体阶梯基准比老客户端大，
+    /// 同一条曲线跑到 1.4 以上就明显过头了。
+    private static let maximumDisplayScale: CGFloat = 1.25
+    private static let displayScaleSlope: CGFloat = 1.7
+
+    static func displayScale(for screen: NSScreen?) -> CGFloat {
+        // 用 visibleFrame 而不是 frame：菜单栏和 Dock 占掉的地方本来就排不了界面，
+        // 把它们算进对角线会让缩放偏大。
+        guard let area = screen?.visibleFrame, area.width > 0, area.height > 0 else { return 1 }
+        let diagonal = hypot(area.width, area.height)
+        let proportional = 1 + ((diagonal / baseWorkAreaDiagonal) - 1) * displayScaleSlope
+        return min(maximumDisplayScale, max(1, proportional))
+    }
+
+    /// 窗口所在的那块屏，而不是 `NSScreen.main`——把窗口从笔记本屏拖到外接屏时，
+    /// `main` 指的是"有键盘焦点的那块"，跨屏拖动过程中它并不总是跟着走。
+    func refreshDisplayScale() {
+        let screen = NSApplication.shared.keyWindow?.screen
+            ?? NSApplication.shared.windows.first(where: { $0.isVisible })?.screen
+            ?? NSScreen.main
+        let next = Self.displayScale(for: screen)
+        guard abs(next - displayScale) > 0.001 else { return }
+        displayScale = next
+    }
+
+    /// 这项偏好只影响渲染、不进 `LegacySettingsSnapshot` 那份 JSON：
+    /// `AppDesign.Typography` 是静态取值点，拿不到 `LegacyDataStore`，
+    /// 再镜像一份就会出现两个真相源。
+    private init() {
+        let stored = UserDefaults.standard.string(forKey: Self.storageKey)
+        fontScale = stored.flatMap(FontScale.init(rawValue:)) ?? .standard
+        displayScale = Self.displayScale(for: NSScreen.main)
+
+        // 接显示器、改分辨率、窗口挪到另一块屏——三件事都要重算。
+        for name in [
+            NSApplication.didChangeScreenParametersNotification,
+            NSWindow.didChangeScreenNotification
+        ] {
+            NotificationCenter.default.addObserver(
+                forName: name,
+                object: nil,
+                queue: .main
+            ) { _ in
+                MainActor.assumeIsolated { InterfaceMetrics.shared.refreshDisplayScale() }
+            }
+        }
+    }
+}
+
+extension Font {
+    /// 跟随「界面字号」档位缩放的系统字体。
+    ///
+    /// View 层不要再直接写 `.system(size:)`：那是固定 pt，调档位不会跟着变。
+    /// 能用 `AppDesign.Typography` 里的档位就优先用档位，这里是给确实不在阶梯上的
+    /// 一次性字号（角标、chevron、超大数字）留的口子。
+    @MainActor
+    static func appScaled(
+        size: CGFloat,
+        weight: Font.Weight = .regular,
+        design: Font.Design = .default
+    ) -> Font {
+        .system(size: size * AppDesign.Typography.scale, weight: weight, design: design)
+    }
+}

--- a/native/Sources/LeetCodeAssistant/Models/WorkspaceState.swift
+++ b/native/Sources/LeetCodeAssistant/Models/WorkspaceState.swift
@@ -484,6 +484,23 @@ final class WorkspaceState {
         }
     }
 
+    /// 全屏动画进行中。系统那段窗口动画大约半秒，期间窗口宽度是连续变化的。
+    private(set) var isWindowTransitioning = false
+
+    /// 系统开始播放全屏动画。断点在这半秒里会被一路扫过，先冻住。
+    func beginWindowTransition() {
+        isWindowTransitioning = true
+    }
+
+    /// 动画落定，按最终宽度一次性把断点算完。
+    func endWindowTransition() {
+        guard isWindowTransitioning else { return }
+        isWindowTransitioning = false
+        let width = pendingWindowWidth ?? windowWidth
+        pendingWindowWidth = nil
+        handleWindowWidth(width)
+    }
+
     func handleFullScreenChange(_ isFullScreen: Bool) {
         guard isWindowFullScreen != isFullScreen else { return }
         // 显式关掉动画：这一下改的是顶栏的排布口径（内缩、偏移、控件归属），
@@ -561,6 +578,11 @@ final class WorkspaceState {
         if windowWidth != width {
             windowWidth = width
         }
+        // 全屏进出的那半秒里宽度是连续变化的，断点会被一路扫过：侧栏、上下文列、
+        // 工具列在动画中途弹进弹出，每一下还各自带着 0.22s 的补间，叠在系统那段
+        // 窗口动画上就是"跳好几下"。动画期间只记宽度，落定后由 `endWindowTransition`
+        // 按最终宽度算一次——中途那些临时状态一个都不该被看到。
+        guard !isWindowTransitioning else { return }
         let newShowsTitle = WindowChromePolicy.showsTitle(current: showsWindowTitle, width: width)
         if newShowsTitle != showsWindowTitle {
             withAnimation(AppDesign.Motion.fade) { showsWindowTitle = newShowsTitle }

--- a/native/Sources/LeetCodeAssistant/Models/WorkspaceState.swift
+++ b/native/Sources/LeetCodeAssistant/Models/WorkspaceState.swift
@@ -288,6 +288,14 @@ final class WorkspaceState {
         }
     }
 
+    /// 界面字号一改，列宽的上下界跟着变（`AppDesign.Size` 里装文字的那一档），
+    /// 但存档里的宽度还是老值——不重新夹一次，就会出现"字放大了、侧栏还是原来那么窄，
+    /// 会话标题反而截得更狠"。
+    func reclampColumnWidths() {
+        setSidebarColumnWidth(sidebarColumnWidth)
+        setInspectorColumnWidth(inspectorColumnWidth)
+    }
+
     func setSidebarColumnWidth(_ width: CGFloat) {
         let clamped = WorkspaceSplitLayoutPolicy.sidebarDividerLimit(proposed: width)
         guard clamped != sidebarColumnWidth else { return }
@@ -701,9 +709,15 @@ final class WorkspaceState {
         static let context: CGFloat = 1_180
         /// True three-column floor: sidebar min + primary min + inspector min.
         /// The old 1280 cutoff compacted the sidebar while all three still fit.
-        static let toolWithSidebar: CGFloat = AppDesign.Size.sidebarMin
-            + AppDesign.Size.primaryMinimum
-            + AppDesign.Size.inspectorMin
+        ///
+        /// 计算属性而不是 `static let`：三列的最小宽现在跟着界面字号走，
+        /// 全局 `let` 会在进程启动时把它定死，调完字号断点还停在老值上。
+        @MainActor
+        static var toolWithSidebar: CGFloat {
+            AppDesign.Size.sidebarMin
+                + AppDesign.Size.primaryMinimum
+                + AppDesign.Size.inspectorMin
+        }
         static let contextWithToolAndSidebar: CGFloat = 1_600
         static let fullWorkspace: CGFloat = 1_850
     }

--- a/native/Sources/LeetCodeAssistant/Views/ConversationWorkspaceView.swift
+++ b/native/Sources/LeetCodeAssistant/Views/ConversationWorkspaceView.swift
@@ -728,7 +728,7 @@ private struct ConversationEmptyStateView<Composer: View>: View {
 
                     TimelineView(.periodic(from: .now, by: 60)) { timeline in
                         Text(timeline.date.formatted(.dateTime.month(.wide).day().weekday(.wide)))
-                            .font(.system(size: 13, weight: .medium))
+                            .font(.appScaled(size: 13, weight: .medium))
                             .foregroundStyle(.secondary)
                     }
                     .padding(.top, compactHeight ? 10 : 18)
@@ -889,7 +889,7 @@ private struct ComposerView: View {
                         .frame(width: 28, height: 28)
                     if !pendingArtifacts.isEmpty {
                         Text("\(pendingArtifacts.count)")
-                            .font(.system(size: 8, weight: .bold).monospacedDigit())
+                            .font(.appScaled(size: 8, weight: .bold).monospacedDigit())
                             .foregroundStyle(.white)
                             .frame(minWidth: 13, minHeight: 13)
                             .background(Color.accentColor, in: Circle())
@@ -935,7 +935,7 @@ private struct ComposerView: View {
 
             Button(action: primaryAction) {
                 Image(systemName: sendButtonSymbol)
-                    .font(.system(size: sendButtonSymbol == "stop.fill" ? 10 : 13, weight: .semibold))
+                    .font(.appScaled(size: sendButtonSymbol == "stop.fill" ? 10 : 13, weight: .semibold))
                     .contentTransition(.symbolEffect(.replace))
                     .foregroundStyle(.white)
                     .frame(width: 30, height: 30)
@@ -971,7 +971,7 @@ private struct ComposerView: View {
     private var queueStatus: some View {
         HStack(spacing: 8) {
             Image(systemName: "text.badge.plus")
-                .font(.system(size: 12, weight: .medium))
+                .font(.appScaled(size: 12, weight: .medium))
                 .foregroundStyle(.secondary)
             Text("待发送 \(queuedDrafts.count) 条")
                 .font(.caption.weight(.semibold))
@@ -982,7 +982,7 @@ private struct ComposerView: View {
             Spacer(minLength: 8)
             Button(action: onClearQueue) {
                 Image(systemName: "xmark")
-                    .font(.system(size: 10, weight: .semibold))
+                    .font(.appScaled(size: 10, weight: .semibold))
                     .frame(width: 22, height: 22)
             }
             .buttonStyle(.plain)
@@ -1058,7 +1058,7 @@ private struct ComposerView: View {
                         .frame(width: 13, height: 13)
                 }
                 Text(activeProvider?.model ?? "选择模型")
-                    .font(.system(size: 12, weight: .medium))
+                    .font(.appScaled(size: 12, weight: .medium))
                     .lineLimit(1)
                     .truncationMode(.middle)
                     .layoutPriority(-1)
@@ -1139,7 +1139,7 @@ private struct ComposerView: View {
         } label: {
             HStack(spacing: 6) {
                 Image(systemName: "checkmark")
-                    .font(.system(size: 10, weight: .bold))
+                    .font(.appScaled(size: 10, weight: .bold))
                     .foregroundStyle(Color.accentColor)
                     .opacity(isActive ? 1 : 0)
                     .frame(width: 12)

--- a/native/Sources/LeetCodeAssistant/Views/KnowledgeGraphWorkspaceView.swift
+++ b/native/Sources/LeetCodeAssistant/Views/KnowledgeGraphWorkspaceView.swift
@@ -180,12 +180,12 @@ struct KnowledgeGraphWorkspaceView: View {
             Image(systemName: "exclamationmark.triangle.fill")
                 .foregroundStyle(AppDesign.ColorToken.warning)
             Text(errorText)
-                .font(.system(size: 12))
+                .font(.appScaled(size: 12))
                 .lineLimit(2)
             Button {
                 errorText = ""
             } label: {
-                Image(systemName: "xmark").font(.system(size: 10))
+                Image(systemName: "xmark").font(.appScaled(size: 10))
             }
             .buttonStyle(.plain)
         }
@@ -200,11 +200,11 @@ struct KnowledgeGraphWorkspaceView: View {
         HStack(spacing: 8) {
             HStack(spacing: 6) {
                 Image(systemName: "magnifyingglass")
-                    .font(.system(size: 11))
+                    .font(.appScaled(size: 11))
                     .foregroundStyle(.secondary)
                 TextField("搜索节点", text: $searchText)
                     .textFieldStyle(.plain)
-                    .font(.system(size: 12.5))
+                    .font(.appScaled(size: 12.5))
                     .frame(width: 130)
                 if !searchText.isEmpty {
                     Button { searchText = "" } label: {
@@ -227,7 +227,7 @@ struct KnowledgeGraphWorkspaceView: View {
                 }
             } label: {
                 Label(isLinking ? (linkDirected ? "单向连线中" : "双向连线中") : "连线", systemImage: "link")
-                    .font(.system(size: 12.5, weight: .medium))
+                    .font(.appScaled(size: 12.5, weight: .medium))
                     .foregroundStyle(isLinking ? Color.accentColor : .secondary)
                     .padding(.horizontal, 11)
                     .frame(height: 30)
@@ -269,7 +269,7 @@ struct KnowledgeGraphWorkspaceView: View {
 
             Button { fitRequest &+= 1 } label: {
                 Image(systemName: "arrow.up.left.and.arrow.down.right")
-                    .font(.system(size: 12))
+                    .font(.appScaled(size: 12))
                     .foregroundStyle(.secondary)
                     .frame(width: 30, height: 30)
                     .contentShape(Circle())
@@ -287,7 +287,7 @@ struct KnowledgeGraphWorkspaceView: View {
     ) -> some View {
         Button(action: action) {
             Label(title, systemImage: systemImage)
-                .font(.system(size: 12, weight: .medium))
+                .font(.appScaled(size: 12, weight: .medium))
                 .foregroundStyle(.secondary)
                 .padding(.horizontal, 8)
                 .frame(height: 26)

--- a/native/Sources/LeetCodeAssistant/Views/LearningCenterViews.swift
+++ b/native/Sources/LeetCodeAssistant/Views/LearningCenterViews.swift
@@ -63,25 +63,37 @@ struct LearningLibraryWorkspaceView: View {
                     } label: {
                         HStack(spacing: 6) {
                             Text(category)
-                                .font(.system(size: 12.5, weight: .medium))
+                                .font(AppDesign.Typography.auxEmphasis)
                                 .lineLimit(1)
+                                .truncationMode(.tail)
+                            Spacer(minLength: 2)
                             Image(systemName: "chevron.up.chevron.down")
-                                .font(.system(size: 9, weight: .semibold))
+                                .font(.appScaled(size: 9, weight: .semibold))
                                 .foregroundStyle(.secondary)
                         }
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 5)
+                        .padding(.horizontal, 10)
+                        .frame(height: AppDesign.Size.toolbarControl)
                         .contentShape(Capsule())
                     }
                     .menuStyle(.borderlessButton)
                     .menuIndicator(.hidden)
+                    // borderlessButton 的 Menu 不理会 label 的尺寸，不锁宽就和兄弟视图平分剩余空间。
+                    // 原来 label 上还写着 `maxWidth: .infinity`，等于主动要满宽：胶囊铺满整条侧栏、
+                    // "全部"被摆到正中间，右边跟着空一大片。锁死宽度后它才回到行首。
+                    .frame(width: 150, height: AppDesign.Size.toolbarControl)
                     .glassCapsule()
                     .help("知识分类")
+                    Spacer(minLength: 8)
                     Text("\(records.count) 项")
                         .font(.caption.monospacedDigit())
                         .foregroundStyle(.secondary)
                 }
-                .padding(10)
+                .padding(.horizontal, 10)
+                // `maxWidth: .infinity` 不能省：不写的话这行 HStack 只有内容那么宽，
+                // 再被 VStack 居中——胶囊和计数一起飘到侧栏正中，左右各空一条。
+                // （Spacer 只有在 HStack 本身被撑满时才推得动东西。）
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .frame(height: AppDesign.Size.pageHeader)
 
                 Divider()
 
@@ -146,7 +158,11 @@ struct LearningLibraryWorkspaceView: View {
                     }
                 }
             }
-            .frame(minWidth: 250, idealWidth: 300, maxWidth: 360)
+            .frame(
+                minWidth: AppDesign.Size.paneListMin,
+                idealWidth: 300,
+                maxWidth: AppDesign.Size.paneListMax
+            )
             .background(AppDesign.ColorToken.canvas)
 
             if let record = selectedRecord {
@@ -208,19 +224,19 @@ private struct LearningRecordDetailView: View {
                 HStack(alignment: .top) {
                     VStack(alignment: .leading, spacing: 6) {
                         Text(record.title)
-                            .font(.system(size: 22, weight: .semibold))
+                            .font(.appScaled(size: 22, weight: .semibold))
                         Text(record.knowledgePath.joined(separator: "  ›  "))
-                            .font(.system(size: 12))
+                            .font(.appScaled(size: 12))
                             .foregroundStyle(.secondary)
                     }
                     Spacer()
                     VStack(alignment: .trailing, spacing: 2) {
                         Text("\(Int(record.effectiveMastery()))%")
-                            .font(.system(size: 20, weight: .semibold).monospacedDigit())
+                            .font(.appScaled(size: 20, weight: .semibold).monospacedDigit())
                         // 显示的是按遗忘曲线折算后的"现在还剩多少"；
                         // 放久了它会自己往下走，不再是一个学会之后就冻住的数字。
                         Text(masteryCaption(record))
-                            .font(.system(size: 11))
+                            .font(.appScaled(size: 11))
                             .foregroundStyle(.secondary)
                     }
                 }
@@ -238,13 +254,13 @@ private struct LearningRecordDetailView: View {
 
                 detailSection("当前诊断") {
                     Text(record.diagnosis.isEmpty ? "等待更多学习证据" : record.diagnosis)
-                        .font(.system(size: 14))
+                        .font(.appScaled(size: 14))
                         .foregroundStyle(.secondary)
                         .lineSpacing(5)
                     FlowLayout(spacing: 6) {
                         ForEach(record.labels, id: \.self) { label in
                             Text(label)
-                                .font(.system(size: 12))
+                                .font(.appScaled(size: 12))
                                 .padding(.horizontal, 9)
                                 .padding(.vertical, 4)
                                 .background(.quaternary, in: Capsule())
@@ -278,10 +294,10 @@ private struct LearningRecordDetailView: View {
                             } label: {
                                 HStack(alignment: .top, spacing: 9) {
                                     Image(systemName: "arrow.up.right.square")
-                                        .font(.system(size: 13))
+                                        .font(.appScaled(size: 13))
                                         .foregroundStyle(.secondary)
                                     Text(source.excerpt)
-                                        .font(.system(size: 13))
+                                        .font(.appScaled(size: 13))
                                         .lineLimit(3)
                                         .multilineTextAlignment(.leading)
                                     Spacer(minLength: 0)
@@ -295,7 +311,9 @@ private struct LearningRecordDetailView: View {
             }
             .padding(.horizontal, 32)
             .padding(.vertical, 30)
-            .frame(maxWidth: 760, alignment: .leading)
+            // 版心统一走 token：写死 760 时窗口越宽左右空得越多，
+            // 对话页当年就是因为 820 太窄、正文左边空一大条才改到 1100 的。
+            .frame(maxWidth: AppDesign.Size.contentColumnMaximum, alignment: .leading)
             .frame(maxWidth: .infinity)
         }
         .floatingScrollIndicators()
@@ -308,7 +326,7 @@ private struct LearningRecordDetailView: View {
                     workspace.selectedSection = .knowledge
                 } label: {
                     Label("在脑图中查看", systemImage: "point.3.connected.trianglepath.dotted")
-                        .font(.system(size: 13, weight: .medium))
+                        .font(.appScaled(size: 13, weight: .medium))
                         .foregroundStyle(.secondary)
                         .padding(.horizontal, 12)
                         .padding(.vertical, 6)
@@ -322,7 +340,7 @@ private struct LearningRecordDetailView: View {
                     workspace.selectedSection = .review
                 } label: {
                     Label("开始练习", systemImage: "play.fill")
-                        .font(.system(size: 13, weight: .medium))
+                        .font(.appScaled(size: 13, weight: .medium))
                         .foregroundStyle(Color.accentColor)
                         .padding(.horizontal, 12)
                         .padding(.vertical, 6)
@@ -340,7 +358,7 @@ private struct LearningRecordDetailView: View {
     private func detailSection<Content: View>(_ title: String, @ViewBuilder content: () -> Content) -> some View {
         VStack(alignment: .leading, spacing: 12) {
             Text(title)
-                .font(.system(size: 13, weight: .semibold))
+                .font(.appScaled(size: 13, weight: .semibold))
                 .foregroundStyle(.secondary)
             content()
         }
@@ -389,7 +407,7 @@ private struct LearningRecordDetailView: View {
                     .background(Color.primary.opacity(0.025), in: RoundedRectangle(cornerRadius: AppDesign.Radius.card, style: .continuous))
                 } else if problemLoadFailed {
                     Text(record.question.isEmpty ? record.title : record.question)
-                        .font(.system(size: 14))
+                        .font(.appScaled(size: 14))
                         .lineSpacing(5)
                         .textSelection(.enabled)
                     Text("题面未能加载，可能是未登录力扣或网络不可用")
@@ -416,7 +434,7 @@ private struct LearningRecordDetailView: View {
             }
         } else {
             Text(record.question.isEmpty ? record.title : record.question)
-                .font(.system(size: 14))
+                .font(.appScaled(size: 14))
                 .lineSpacing(5)
                 .textSelection(.enabled)
         }
@@ -577,7 +595,7 @@ private struct LearningRecordDetailView: View {
             detailSection("AI 解题分析") {
                 if !analysis.summary.isEmpty, !duplicatesDiagnosis {
                     Text(analysis.summary)
-                        .font(.system(size: 14))
+                        .font(.appScaled(size: 14))
                         .lineSpacing(6)
                         .textSelection(.enabled)
                 }
@@ -707,6 +725,9 @@ private struct LearningRecordDetailView: View {
 struct LearningInsightsWorkspaceView: View {
     @Bindable var workspace: WorkspaceState
     @Bindable var dataStore: LegacyDataStore
+    /// 版心的实际可用宽度。断点按它算而不是按窗口：这一页左边还有全局侧栏，
+    /// 侧栏收起来时同一个窗口能多出 256pt，卡片该多排一列。
+    @State private var contentWidth: CGFloat = 0
 
     private var records: [LearningRecord] { dataStore.learningRecords }
     private var focus: [LearningRecord] { LearningInsights.focus(records: dataStore.activeLearningRecords) }
@@ -730,23 +751,36 @@ struct LearningInsightsWorkspaceView: View {
 
                     // 两列等高：不给 maxHeight 的话短的那张卡会缩成一半，
                     // 和右边的长卡片底边对不齐。
-                    HStack(alignment: .top, spacing: AppDesign.Spacing.rowInset) {
-                        focusCard
-                        topicCard
+                    // 窄到并排放不下时改成上下排——并排时每张不足 360pt，
+                    // 主题名和条形图都要折行，读起来比堆两行还费劲。
+                    if contentWidth >= Self.twoColumnBreakpoint {
+                        HStack(alignment: .top, spacing: AppDesign.Spacing.rowInset) {
+                            focusCard
+                            topicCard
+                        }
+                        .fixedSize(horizontal: false, vertical: true)
+                    } else {
+                        VStack(spacing: AppDesign.Spacing.rowInset) {
+                            focusCard
+                            topicCard
+                        }
                     }
-                    .fixedSize(horizontal: false, vertical: true)
 
                     forecastCard
                 }
             }
             .padding(.horizontal, AppDesign.Spacing.lg)
             .padding(.vertical, AppDesign.Spacing.lg)
-            .frame(maxWidth: 1_120, alignment: .leading)
+            .frame(maxWidth: AppDesign.Size.dashboardColumnMaximum, alignment: .leading)
             .frame(maxWidth: .infinity)
+            .onGeometryChange(for: CGFloat.self) { $0.size.width } action: { contentWidth = $0 }
         }
         .floatingScrollIndicators()
         .background(AppDesign.ColorToken.canvas)
     }
+
+    /// 两张主卡并排的下限。低于它就叠成一列。
+    private static let twoColumnBreakpoint: CGFloat = 900
 
     private var header: some View {
         VStack(alignment: .leading, spacing: 2) {
@@ -761,8 +795,16 @@ struct LearningInsightsWorkspaceView: View {
 
     // MARK: - 概览
 
+    /// 指标卡的列数。**不用 `GridItem(.adaptive(minimum:))`**：adaptive 是按
+    /// "最小宽度能塞下几列"算列数的，1600pt 宽会算出 8 列，4 张卡只填前 4 格、
+    /// 每张卡还是 200pt，右边空一半。列数自己按断点定，卡片才会撑满。
+    private var metricColumns: [GridItem] {
+        let count = contentWidth >= 820 ? 4 : (contentWidth >= 460 ? 2 : 1)
+        return Array(repeating: GridItem(.flexible(), spacing: AppDesign.Spacing.sm), count: count)
+    }
+
     private var metricStrip: some View {
-        HStack(alignment: .top, spacing: AppDesign.Spacing.sm) {
+        LazyVGrid(columns: metricColumns, alignment: .leading, spacing: AppDesign.Spacing.sm) {
             metric("学习项", value: records.count, detail: "累计沉淀", icon: "books.vertical", tint: .accentColor)
             metric(
                 "已到期",
@@ -786,7 +828,6 @@ struct LearningInsightsWorkspaceView: View {
                 tint: .green
             )
         }
-        .fixedSize(horizontal: false, vertical: true)
     }
 
     private func metric(_ title: String, value: Int, detail: String, icon: String, tint: Color) -> some View {
@@ -1028,7 +1069,10 @@ struct LearningTemplatesWorkspaceView: View {
         // 不用 HSplitView：它给每个 pane 画不透明底，圆角卡外面会套出直角矩形。
         HStack(alignment: .top, spacing: AppDesign.Spacing.sm) {
             templateSidebar
-                .frame(minWidth: 268, maxWidth: 268, maxHeight: .infinity)
+                .paneListColumn(
+                    storageKey: "native.paneList.templates",
+                    defaultWidth: 268
+                )
 
             if let template = selectedTemplate {
                 templateDetail(template)
@@ -1143,7 +1187,7 @@ struct LearningTemplatesWorkspaceView: View {
                     ForEach(Array(template.applicableWhen.enumerated()), id: \.offset) { _, value in
                         HStack(alignment: .firstTextBaseline, spacing: 8) {
                             Image(systemName: "checkmark")
-                                .font(.system(size: 10, weight: .bold))
+                                .font(.appScaled(size: 10, weight: .bold))
                                 .foregroundStyle(Color.accentColor)
                                 .frame(width: 12)
                             Text(value)
@@ -1280,7 +1324,7 @@ private struct LearningSidebarSearchField: View {
     var body: some View {
         HStack(spacing: 8) {
             Image(systemName: "magnifyingglass")
-                .font(.system(size: 13, weight: .medium))
+                .font(.appScaled(size: 13, weight: .medium))
                 .foregroundStyle(.secondary)
             TextField(prompt, text: $text)
                 .textFieldStyle(.plain)

--- a/native/Sources/LeetCodeAssistant/Views/LearningWorkspaces.swift
+++ b/native/Sources/LeetCodeAssistant/Views/LearningWorkspaces.swift
@@ -43,7 +43,11 @@ struct ReviewWorkspaceView: View {
     var body: some View {
         HSplitView {
             reviewQueue
-                .frame(minWidth: 244, idealWidth: 276, maxWidth: 312)
+                .frame(
+                    minWidth: AppDesign.Size.paneListMin,
+                    idealWidth: 276,
+                    maxWidth: AppDesign.Size.paneListMax
+                )
 
             reviewDetail
                 .frame(minWidth: 540, maxWidth: .infinity, maxHeight: .infinity)
@@ -145,7 +149,7 @@ struct ReviewWorkspaceView: View {
 
             HStack(spacing: 7) {
                 Image(systemName: "magnifyingglass")
-                    .font(.system(size: 12))
+                    .font(.appScaled(size: 12))
                     .foregroundStyle(.secondary)
                 TextField("搜索复习项", text: $searchText)
                     .textFieldStyle(.plain)
@@ -257,7 +261,7 @@ struct ReviewWorkspaceView: View {
                         Spacer()
                     }
                 }
-                .frame(maxWidth: 760, alignment: .leading)
+                .frame(maxWidth: AppDesign.Size.contentColumnMaximum, alignment: .leading)
                 .padding(.horizontal, 32)
                 .padding(.top, 28)
                 .padding(.bottom, 56)
@@ -336,7 +340,7 @@ struct ReviewWorkspaceView: View {
                     showLessonInGraph()
                 } label: {
                     Image(systemName: "point.3.connected.trianglepath.dotted")
-                        .font(.system(size: 12, weight: .medium))
+                        .font(.appScaled(size: 12, weight: .medium))
                         .foregroundStyle(.secondary)
                         .frame(width: 26, height: 26)
                         .contentShape(Circle())
@@ -349,7 +353,7 @@ struct ReviewWorkspaceView: View {
                     Task { await preparePackageIfNeeded(force: true) }
                 } label: {
                     Image(systemName: "arrow.clockwise")
-                        .font(.system(size: 12, weight: .medium))
+                        .font(.appScaled(size: 12, weight: .medium))
                         .foregroundStyle(.secondary)
                         .frame(width: 26, height: 26)
                         .contentShape(Circle())
@@ -444,7 +448,7 @@ struct ReviewWorkspaceView: View {
         VStack(alignment: .leading, spacing: 10) {
             HStack(alignment: .firstTextBaseline, spacing: 8) {
                 Text("现在还记得吗")
-                    .font(.system(size: 13, weight: .semibold))
+                    .font(.appScaled(size: 13, weight: .semibold))
                 Text("评分直接决定下一次复习时间")
                     .font(AppDesign.Typography.micro)
                     .foregroundStyle(.secondary)
@@ -460,9 +464,9 @@ struct ReviewWorkspaceView: View {
                     } label: {
                         HStack(spacing: 5) {
                             Image(systemName: rating.symbol)
-                                .font(.system(size: 11, weight: .semibold))
+                                .font(.appScaled(size: 11, weight: .semibold))
                             Text(rating.title)
-                                .font(.system(size: 12.5, weight: .medium))
+                                .font(.appScaled(size: 12.5, weight: .medium))
                         }
                         .foregroundStyle(rating.tint)
                         .frame(maxWidth: .infinity)
@@ -516,7 +520,7 @@ struct ReviewWorkspaceView: View {
                     selectedRecord?.activeStudyPackage == nil ? "生成讲解与检测" : "重新生成",
                     systemImage: "sparkles"
                 )
-                .font(.system(size: 12.5, weight: .medium))
+                .font(.appScaled(size: 12.5, weight: .medium))
                 .foregroundStyle(Color.accentColor)
                 .padding(.horizontal, 10)
                 .padding(.vertical, 5)
@@ -620,7 +624,7 @@ struct ReviewWorkspaceView: View {
                         Task { await submitAttempt(record) }
                     } label: {
                         Label("提交检测", systemImage: "paperplane.fill")
-                            .font(.system(size: 13, weight: .medium))
+                            .font(.appScaled(size: 13, weight: .medium))
                             .foregroundStyle(canSubmit ? Color.accentColor : .secondary)
                             .padding(.horizontal, 12)
                             .padding(.vertical, 6)
@@ -962,7 +966,7 @@ struct GlassSegmentedControl: View {
                     selection = option.value
                 } label: {
                     Text(option.label)
-                        .font(.system(size: 12.5, weight: isSelected ? .semibold : .regular))
+                        .font(.appScaled(size: 12.5, weight: isSelected ? .semibold : .regular))
                         .foregroundStyle(isSelected ? .primary : .secondary)
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 5)

--- a/native/Sources/LeetCodeAssistant/Views/LeetCodeSolutionViews.swift
+++ b/native/Sources/LeetCodeAssistant/Views/LeetCodeSolutionViews.swift
@@ -364,7 +364,7 @@ struct LeetCodeProblemNavBar: View {
             if let slug { onSelect(slug) }
         } label: {
             Image(systemName: systemImage)
-                .font(.system(size: 11, weight: .semibold))
+                .font(.appScaled(size: 11, weight: .semibold))
                 .frame(width: 22, height: 22)
                 .contentShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
         }
@@ -417,13 +417,18 @@ struct LeetCodeSolutionsBrowser: View {
 
             HStack(spacing: 0) {
                 solutionList
-                    .frame(width: 248)
+                    .paneListColumn(
+                        storageKey: "native.paneList.solutionList",
+                        defaultWidth: 248,
+                        minWidth: 200,
+                        maxWidth: 380
+                    )
                 Divider()
                 solutionDetail
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
         }
-        .frame(minWidth: 980, idealWidth: 1180, maxWidth: 1440)
+        .frame(minWidth: 980, idealWidth: 1180, maxWidth: AppDesign.Size.dashboardColumnMaximum)
         .frame(minHeight: 700, idealHeight: 800, maxHeight: 1040)
         .background(AppDesign.ColorToken.canvas)
         .task { await loadList() }
@@ -461,7 +466,7 @@ struct LeetCodeSolutionsBrowser: View {
                 // 官方题解（作者 LeetCode-Solution）单独标出来——列表里最该先看的就是它。
                 if item.isOfficial {
                     Text("官方")
-                        .font(.system(size: 9, weight: .semibold))
+                        .font(.appScaled(size: 9, weight: .semibold))
                         .foregroundStyle(.white)
                         .padding(.horizontal, 4)
                         .padding(.vertical, 1)
@@ -469,7 +474,7 @@ struct LeetCodeSolutionsBrowser: View {
                 }
                 Text(item.authorName).lineLimit(1)
                 Spacer(minLength: 4)
-                Image(systemName: "eye").font(.system(size: 9))
+                Image(systemName: "eye").font(.appScaled(size: 9))
                 Text(LeetCodeQuestionActionBar.compactCount(item.views)).monospacedDigit()
             }
             .font(AppDesign.Typography.micro)

--- a/native/Sources/LeetCodeAssistant/Views/LeetCodeWorkspaceView.swift
+++ b/native/Sources/LeetCodeAssistant/Views/LeetCodeWorkspaceView.swift
@@ -173,7 +173,7 @@ struct LeetCodeWorkspaceView: View {
                 } label: {
                     HStack(spacing: 5) {
                         Text(activePlanName).lineLimit(1)
-                        Image(systemName: "chevron.down").font(.system(size: 9, weight: .semibold))
+                        Image(systemName: "chevron.down").font(.appScaled(size: 9, weight: .semibold))
                     }
                     .frame(maxWidth: 180, alignment: .leading)
                 }
@@ -195,7 +195,7 @@ struct LeetCodeWorkspaceView: View {
                 dataStore.reload()
             } label: {
                 Image(systemName: "arrow.clockwise")
-                    .font(.system(size: 12, weight: .medium))
+                    .font(.appScaled(size: 12, weight: .medium))
                     .foregroundStyle(.secondary)
                     .frame(width: 26, height: 26)
                     .contentShape(Circle())
@@ -280,7 +280,7 @@ struct LeetCodeWorkspaceView: View {
         HStack {
             VStack(alignment: .leading, spacing: 2) {
                 Text("\(value)\(suffix)")
-                    .font(.system(size: 19, weight: .semibold).monospacedDigit())
+                    .font(.appScaled(size: 19, weight: .semibold).monospacedDigit())
                     .foregroundStyle(color)
                 Text(title).font(.caption).foregroundStyle(.secondary)
             }
@@ -351,7 +351,7 @@ struct LeetCodeWorkspaceView: View {
                     .foregroundStyle(.secondary)
                     .frame(width: 44, alignment: .trailing)
                 VStack(alignment: .leading, spacing: 3) {
-                    Text(question.title).font(.system(size: 14, weight: .medium)).lineLimit(1)
+                    Text(question.title).font(.appScaled(size: 14, weight: .medium)).lineLimit(1)
                     Text(([question.groupName] + question.topicTags.prefix(3)).filter { !$0.isEmpty }.joined(separator: " · "))
                         .font(.caption).foregroundStyle(.secondary).lineLimit(1)
                 }
@@ -456,7 +456,7 @@ struct LeetCodeWorkspaceView: View {
             Image(nsImage: image).resizable().scaledToFill()
                 .frame(width: 54, height: 54).clipShape(RoundedRectangle(cornerRadius: 10))
         } else {
-            Image(systemName: "person.crop.square").font(.system(size: 34)).foregroundStyle(.secondary)
+            Image(systemName: "person.crop.square").font(.appScaled(size: 34)).foregroundStyle(.secondary)
                 .frame(width: 54, height: 54)
         }
     }
@@ -543,7 +543,7 @@ struct LeetCodeWorkspaceView: View {
                 Circle().fill(submission.accepted ? Color.green : Color.orange).frame(width: 7, height: 7)
                 VStack(alignment: .leading, spacing: 2) {
                     Text("\(submission.frontendID). \(submission.title)")
-                        .font(.system(size: compact ? 13.5 : 14, weight: .medium)).lineLimit(1)
+                        .font(.appScaled(size: compact ? 13.5 : 14, weight: .medium)).lineLimit(1)
                     Text([submission.status.isEmpty ? (submission.accepted ? "通过" : "未通过") : submission.status,
                           submission.language.uppercased(), submission.runtime, submission.memory,
                           submission.submittedAt.formatted(date: .abbreviated, time: .shortened)]
@@ -571,7 +571,7 @@ struct LeetCodeWorkspaceView: View {
                 .buttonStyle(.plain).help("返回题库")
             if let question = selectedQuestion {
                 Text("\(question.frontendID). \(question.title)")
-                    .font(.system(size: 14, weight: .semibold)).lineLimit(1)
+                    .font(.appScaled(size: 14, weight: .semibold)).lineLimit(1)
                 Text(difficultyTitle(question.difficulty))
                     .font(.caption.weight(.medium)).foregroundStyle(difficultyColor(question.difficulty))
             }
@@ -598,7 +598,7 @@ struct LeetCodeWorkspaceView: View {
                 workspace.openURL(url)
             } label: {
                 Image(systemName: "globe")
-                    .font(.system(size: 12, weight: .medium))
+                    .font(.appScaled(size: 12, weight: .medium))
                     .foregroundStyle(.secondary)
                     .frame(width: 26, height: 26)
                     .contentShape(Circle())
@@ -634,7 +634,7 @@ struct LeetCodeWorkspaceView: View {
                             Task { await ensureWorkspace(slug, force: true) }
                         } label: {
                             Label("重新加载", systemImage: "arrow.clockwise")
-                                .font(.system(size: 12.5, weight: .medium))
+                                .font(.appScaled(size: 12.5, weight: .medium))
                                 .foregroundStyle(Color.accentColor)
                                 .padding(.horizontal, 10)
                                 .padding(.vertical, 5)
@@ -990,7 +990,7 @@ struct LeetCodeWorkspaceView: View {
     ) -> some View {
         Button(action: action) {
             Image(systemName: systemName)
-                .font(.system(size: 12.5, weight: .medium))
+                .font(.appScaled(size: 12.5, weight: .medium))
                 .foregroundStyle(.secondary)
                 .frame(width: 26, height: 26)
                 .contentShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
@@ -1016,10 +1016,10 @@ struct LeetCodeWorkspaceView: View {
             } label: {
                 HStack(spacing: 6) {
                     Text(selectedWorkspace?.snippets.first { $0.languageSlug == selectedLanguage }?.language ?? selectedLanguage)
-                        .font(.system(size: 12.5, weight: .medium))
+                        .font(.appScaled(size: 12.5, weight: .medium))
                         .lineLimit(1)
                     Image(systemName: "chevron.up.chevron.down")
-                        .font(.system(size: 9, weight: .semibold))
+                        .font(.appScaled(size: 9, weight: .semibold))
                         .foregroundStyle(.secondary)
                 }
                 .frame(width: 108)
@@ -1069,10 +1069,10 @@ struct LeetCodeWorkspaceView: View {
         } label: {
             HStack(spacing: 5) {
                 Image(systemName: isHinting ? "ellipsis" : "lightbulb.max")
-                    .font(.system(size: 12, weight: .medium))
+                    .font(.appScaled(size: 12, weight: .medium))
                     .symbolEffect(.pulse, isActive: isHinting)
                 Text(codeHints.isEmpty ? "AI 提示" : "提示 \(codeHints.count)/3")
-                    .font(.system(size: 12.5, weight: .medium))
+                    .font(.appScaled(size: 12.5, weight: .medium))
             }
             .foregroundStyle(codeHints.isEmpty ? Color.secondary : Color.accentColor)
             .padding(.horizontal, 11)
@@ -1394,7 +1394,7 @@ struct LeetCodeWorkspaceView: View {
     ) -> some View {
         Button(action: action) {
             Label(title, systemImage: systemImage)
-                .font(.system(size: 12.5, weight: .medium))
+                .font(.appScaled(size: 12.5, weight: .medium))
                 .foregroundStyle(tint)
                 .padding(.horizontal, 10)
                 .padding(.vertical, 5)

--- a/native/Sources/LeetCodeAssistant/Views/PaneListColumn.swift
+++ b/native/Sources/LeetCodeAssistant/Views/PaneListColumn.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+
+/// 页内列表列（算法模板列表、学习计划日历这类"二级侧栏"）。
+///
+/// **为什么需要它**：这些列原来是写死的 pt——`minWidth: 268, maxWidth: 268`、
+/// `minWidth: 344, maxWidth: 344`——上下界一样就等于焊死。窗口从 1440 拉到 1920，
+/// 它们纹丝不动，多出来的 480pt 全给了右边；列表里被截断的标题拉多宽都还是截断的。
+///
+/// 这里给它们一条统一的可拖区间，用的是第一列分栏线那同一个 `ColumnResizeHandle`
+/// （光标、8pt 抓取带、拖动时锁窗口移动的处理都现成）。宽度按页各存各的：
+/// 日历和模板列表想要的宽度本来就不一样，共用一个键会互相打架。
+///
+/// 不改成 `HSplitView`：那会给每个 pane 画自己的不透明底，圆角玻璃卡外面又套出
+/// 一个直角矩形，背景渐变也被挡住——这两页当初就是因为这个才从 HSplitView 换回 HStack 的。
+struct PaneListColumnModifier: ViewModifier {
+    let storageKey: String
+    let defaultWidth: CGFloat
+    let range: ClosedRange<CGFloat>
+
+    @State private var width: CGFloat?
+
+    private var current: CGFloat { width ?? defaultWidth }
+
+    func body(content: Content) -> some View {
+        content
+            .frame(width: current)
+            .frame(maxHeight: .infinity)
+            .overlay(alignment: .trailing) {
+                ColumnResizeHandle(
+                    width: current,
+                    range: range,
+                    growsOnDragRight: true
+                ) { newValue in
+                    width = newValue
+                    UserDefaults.standard.set(Double(newValue), forKey: storageKey)
+                }
+            }
+            .onAppear {
+                guard width == nil else { return }
+                let stored = UserDefaults.standard.double(forKey: storageKey)
+                // 存过的值也要重新夹一遍：区间以后可能收窄，旧值不该把列顶出界。
+                width = stored > 0 ? min(max(stored, range.lowerBound), range.upperBound) : defaultWidth
+            }
+    }
+}
+
+extension View {
+    /// - Parameters:
+    ///   - storageKey: 这一列自己的宽度存档键，各页不共用。
+    ///   - defaultWidth: 没存过时的初始宽度，保持各页原本的观感。
+    ///   - minWidth: 下限。日历那种有固定列数的内容要比列表给得高一些。
+    func paneListColumn(
+        storageKey: String,
+        defaultWidth: CGFloat,
+        minWidth: CGFloat = AppDesign.Size.paneListMin,
+        maxWidth: CGFloat = AppDesign.Size.paneListMax
+    ) -> some View {
+        modifier(
+            PaneListColumnModifier(
+                storageKey: storageKey,
+                defaultWidth: defaultWidth,
+                range: minWidth...maxWidth
+            )
+        )
+    }
+}

--- a/native/Sources/LeetCodeAssistant/Views/RootWorkspaceView.swift
+++ b/native/Sources/LeetCodeAssistant/Views/RootWorkspaceView.swift
@@ -101,10 +101,20 @@ struct RootWorkspaceView: View {
         // 顶栏布局（上移一个标题栏、左内缩 78pt、两处 offset）会在画面已经稳定
         // 之后突然整体跳一下。will* 在动画开始时就发，这一跳就藏在系统动画里。
         .onReceive(NotificationCenter.default.publisher(for: NSWindow.willEnterFullScreenNotification)) { _ in
+            workspace.beginWindowTransition()
             workspace.handleFullScreenChange(true)
         }
         .onReceive(NotificationCenter.default.publisher(for: NSWindow.willExitFullScreenNotification)) { _ in
+            workspace.beginWindowTransition()
             workspace.handleFullScreenChange(false)
+        }
+        // did* 才是"系统动画播完了"。断点在这里按最终宽度算一次，
+        // 中途扫过的那些临时状态一个都不会被看到。
+        .onReceive(NotificationCenter.default.publisher(for: NSWindow.didEnterFullScreenNotification)) { _ in
+            workspace.endWindowTransition()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSWindow.didExitFullScreenNotification)) { _ in
+            workspace.endWindowTransition()
         }
         // 内容一路画到窗口顶端，列头才能和红绿灯同处一行（窗口态下标题栏那 28pt
         // 否则会把列头整个挤到第二行）。

--- a/native/Sources/LeetCodeAssistant/Views/RootWorkspaceView.swift
+++ b/native/Sources/LeetCodeAssistant/Views/RootWorkspaceView.swift
@@ -26,6 +26,15 @@ struct RootWorkspaceView: View {
         .onChange(of: dataStore.settings.alwaysOnTop) { _, value in
             applyWindowLevel(value)
         }
+        // 窗口出现之后才知道自己落在哪块屏上——`InterfaceMetrics` 初始化时只能问
+        // `NSScreen.main`，那时窗口还没摆好，接了外接屏也算不出正确的自动档。
+        .task {
+            InterfaceMetrics.shared.refreshDisplayScale()
+        }
+        // 倍率一变，列宽的上下界跟着变，存档里的宽度要重新夹一次。
+        .onChange(of: InterfaceMetrics.shared.scale) { _, _ in
+            workspace.reclampColumnWidths()
+        }
         // 提交分析队列的所有权属于 App，不属于刷题页。挂在页面上时，
         // 导航离开会取消 worker，而取消曾被记成分析失败并耗尽重试预算。
         .task {
@@ -921,7 +930,9 @@ enum ContextPanelOverlayPolicy {
     }
 }
 
-/// 对话列头标题与正文 / 输入框共用的中轴：列宽减去右侧浮层后，在 820 内容宽上居中。
+/// 对话列头标题与正文 / 输入框共用的中轴：列宽减去右侧浮层后，在内容宽上居中。
+/// `@MainActor`：内容列宽跟着界面字号走（`AppDesign.Size`）。
+@MainActor
 enum ConversationColumnLayout {
     static var contentMaximum: CGFloat { AppDesign.Size.contentColumnMaximum }
     static var minimumInset: CGFloat { AppDesign.Spacing.lg }
@@ -955,6 +966,8 @@ enum ConversationColumnLayout {
     }
 }
 
+/// `@MainActor`：判据里的正文列宽跟着界面字号走（`AppDesign.Size`）。
+@MainActor
 enum QuestionRailPresentationPolicy {
     static let minimumQuestionCount = 6
     static let tickStride: CGFloat = 15

--- a/native/Sources/LeetCodeAssistant/Views/SettingsView.swift
+++ b/native/Sources/LeetCodeAssistant/Views/SettingsView.swift
@@ -29,7 +29,7 @@ struct SettingsView: View {
                     HStack(spacing: 8) {
                         Button(action: onDismiss) {
                             Label("返回应用", systemImage: "chevron.left")
-                                .font(.system(size: 15))
+                                .font(.appScaled(size: 15))
                                 .frame(height: 32)
                         }
                         .buttonStyle(.plain)
@@ -39,7 +39,7 @@ struct SettingsView: View {
 
                         Button { dataStore.reload() } label: {
                             Image(systemName: "arrow.clockwise")
-                                .font(.system(size: 15))
+                                .font(.appScaled(size: 15))
                                 .frame(width: 32, height: 32)
                         }
                         .buttonStyle(.plain)
@@ -49,10 +49,10 @@ struct SettingsView: View {
 
                     HStack(spacing: 8) {
                         Image(systemName: "magnifyingglass")
-                            .font(.system(size: 14))
+                            .font(.appScaled(size: 14))
                             .foregroundStyle(.secondary)
                         TextField("搜索设置…", text: $searchText)
-                            .font(.system(size: 14))
+                            .font(.appScaled(size: 14))
                             .textFieldStyle(.plain)
                     }
                     .padding(.horizontal, 12)
@@ -65,7 +65,7 @@ struct SettingsView: View {
                     LazyVStack(alignment: .leading, spacing: 3) {
                         ForEach(visibleGroups) { group in
                             Text(group.title)
-                                .font(.system(size: 13, weight: .medium))
+                                .font(.appScaled(size: 13, weight: .medium))
                                 .foregroundStyle(.secondary)
                                 .padding(.leading, 12)
                                 .padding(.top, 18)
@@ -118,7 +118,7 @@ struct SettingsView: View {
                     .font(AppDesign.Typography.body)
                     .foregroundStyle(.secondary)
             }
-            .frame(maxWidth: 740, alignment: .leading)
+            .frame(maxWidth: AppDesign.Size.settingsColumn, alignment: .leading)
             Spacer(minLength: 0)
         }
         .padding(.top, 30)
@@ -131,12 +131,12 @@ struct SettingsView: View {
         } label: {
             HStack(spacing: 10) {
                 Image(systemName: section.systemImage)
-                    .font(.system(size: 16))
+                    .font(.appScaled(size: 16))
                     .symbolRenderingMode(.hierarchical)
                     .foregroundStyle(selection == section ? Color.accentColor : Color.secondary)
                     .frame(width: 24)
                 Text(section.title)
-                    .font(.system(size: 14, weight: selection == section ? .medium : .regular))
+                    .font(.appScaled(size: 14, weight: selection == section ? .medium : .regular))
                 Spacer()
             }
             .padding(.horizontal, 10)
@@ -243,7 +243,7 @@ private struct SettingsSectionGroup: Identifiable {
 // MARK: - Codex 式设置组件
 
 private struct SettingsScroll<Content: View>: View {
-    var maxWidth: CGFloat = 740
+    var maxWidth: CGFloat = AppDesign.Size.settingsColumn
     @ViewBuilder let content: Content
 
     var body: some View {
@@ -273,13 +273,13 @@ private struct SettingsCard<Content: View>: View {
             HStack(spacing: 7) {
                 if let systemImage {
                     Image(systemName: systemImage)
-                        .font(.system(size: 11, weight: .semibold))
+                        .font(.appScaled(size: 11, weight: .semibold))
                         .foregroundStyle(tint)
                         .frame(width: 22, height: 22)
                         .background(tint.opacity(0.12), in: RoundedRectangle(cornerRadius: 7, style: .continuous))
                 }
                 Text(title)
-                    .font(.system(size: 12, weight: .semibold))
+                    .font(.appScaled(size: 12, weight: .semibold))
                     .foregroundStyle(.secondary)
             }
             .padding(.leading, 4)
@@ -384,10 +384,10 @@ private struct SettingsSliderRow<Control: View>: View {
         VStack(alignment: .leading, spacing: 10) {
             HStack {
                 Text(title)
-                    .font(.system(size: 15, weight: .medium))
+                    .font(.appScaled(size: 15, weight: .medium))
                 Spacer()
                 Text(valueText)
-                    .font(.system(size: 14))
+                    .font(.appScaled(size: 14))
                     .monospacedDigit()
                     .foregroundStyle(.secondary)
             }
@@ -621,7 +621,7 @@ struct BrowserHistorySheet: View {
                                     HStack(spacing: 12) {
                                     Image(systemName: "globe").foregroundStyle(.secondary).frame(width: 24)
                                     VStack(alignment: .leading, spacing: 2) {
-                                        Text(entry.title).font(.system(size: 14, weight: .medium)).lineLimit(1)
+                                        Text(entry.title).font(.appScaled(size: 14, weight: .medium)).lineLimit(1)
                                         Text(entry.url.absoluteString).font(.caption).foregroundStyle(.secondary).lineLimit(1)
                                     }
                                     Spacer()
@@ -858,12 +858,12 @@ private struct ProfileSettingsPage: View {
     }
 
     var body: some View {
-        SettingsScroll(maxWidth: 980) {
+        SettingsScroll {
             VStack(spacing: 12) {
                 profileAvatar
                     .frame(width: 82, height: 82)
                     .clipShape(Circle())
-                Text(displayName).font(.system(size: 26, weight: .semibold))
+                Text(displayName).font(.appScaled(size: 26, weight: .semibold))
                 HStack(spacing: 7) {
                     Text(accountLabel).foregroundStyle(.secondary)
                     Text("·").foregroundStyle(.tertiary)
@@ -955,7 +955,7 @@ private struct ProfileSettingsPage: View {
         ZStack {
             Circle().fill(Color.accentColor.opacity(0.14))
             Text(String(displayName.prefix(1)).uppercased())
-                .font(.system(size: 30, weight: .medium)).foregroundStyle(Color.accentColor)
+                .font(.appScaled(size: 30, weight: .medium)).foregroundStyle(Color.accentColor)
         }
     }
 
@@ -976,12 +976,12 @@ private struct ProfileSettingsPage: View {
         } label: {
             VStack(spacing: 5) {
                 Text(metricValue(item))
-                    .font(.system(size: 25, weight: .semibold).monospacedDigit())
+                    .font(.appScaled(size: 25, weight: .semibold).monospacedDigit())
                     .lineLimit(1)
                     .minimumScaleFactor(0.6)
                 HStack(spacing: 4) {
                     Image(systemName: item.systemImage)
-                        .font(.system(size: 10, weight: .semibold))
+                        .font(.appScaled(size: 10, weight: .semibold))
                     Text(item.title)
                         .font(.caption)
                 }
@@ -1104,7 +1104,7 @@ private struct ProfileSettingsPage: View {
             ForEach(items, id: \.0) { item in
                 VStack(alignment: .leading, spacing: 2) {
                     Text(item.1)
-                        .font(.system(size: 15, weight: .medium).monospacedDigit())
+                        .font(.appScaled(size: 15, weight: .medium).monospacedDigit())
                         .lineLimit(1)
                         .minimumScaleFactor(0.7)
                     Text(item.0).font(.caption).foregroundStyle(.secondary).lineLimit(1)
@@ -1118,7 +1118,7 @@ private struct ProfileSettingsPage: View {
     private var activityHeader: some View {
         HStack(alignment: .firstTextBaseline, spacing: 10) {
             Text("\(activity.total) 次提交")
-                .font(.system(size: 15, weight: .semibold).monospacedDigit())
+                .font(.appScaled(size: 15, weight: .semibold).monospacedDigit())
             Text("· 活跃 \(activity.activeDays) 天 · 当前连续 \(activity.currentStreak) 天 · 最长 \(activity.longestStreak) 天")
                 .font(.caption)
                 .foregroundStyle(.secondary)
@@ -1150,7 +1150,7 @@ private struct ProfileSettingsPage: View {
             VStack(spacing: spacing) {
                 ForEach(0..<7, id: \.self) { row in
                     Text(["", "一", "", "三", "", "五", ""][row])
-                        .font(.system(size: 9))
+                        .font(.appScaled(size: 9))
                         .foregroundStyle(.tertiary)
                         .frame(width: 14, height: cell, alignment: .trailing)
                 }
@@ -1162,7 +1162,7 @@ private struct ProfileSettingsPage: View {
                     Color.clear.frame(height: 12)
                     ForEach(activity.monthMarks) { mark in
                         Text(mark.title)
-                            .font(.system(size: 9))
+                            .font(.appScaled(size: 9))
                             .foregroundStyle(.tertiary)
                             .fixedSize()
                             .offset(x: CGFloat(mark.column) * step)
@@ -1193,7 +1193,7 @@ private struct ProfileSettingsPage: View {
                             // 90 天视图格子够大，直接把日期写进去，不用靠悬停猜。
                             if cell > 20 {
                                 let text = Text("\(Calendar.current.component(.day, from: day))")
-                                    .font(.system(size: 9, weight: .medium).monospacedDigit())
+                                    .font(.appScaled(size: 9, weight: .medium).monospacedDigit())
                                     .foregroundStyle(count >= 4 ? Color.white.opacity(0.9) : Color.secondary)
                                 context.draw(text, at: CGPoint(x: rect.midX, y: rect.midY))
                             }
@@ -1257,13 +1257,13 @@ private struct ProfileSettingsPage: View {
                     .foregroundStyle(.secondary)
             }
             Spacer(minLength: 8)
-            Text("少").font(.system(size: 9)).foregroundStyle(.tertiary)
+            Text("少").font(.appScaled(size: 9)).foregroundStyle(.tertiary)
             ForEach([0, 1, 2, 5, 9], id: \.self) { level in
                 RoundedRectangle(cornerRadius: 3, style: .continuous)
                     .fill(activityColor(level))
                     .frame(width: 11, height: 11)
             }
-            Text("多").font(.system(size: 9)).foregroundStyle(.tertiary)
+            Text("多").font(.appScaled(size: 9)).foregroundStyle(.tertiary)
         }
     }
 
@@ -1273,14 +1273,14 @@ private struct ProfileSettingsPage: View {
         VStack(alignment: .leading, spacing: 9) {
             HStack(spacing: 8) {
                 Text(day.formatted(.dateTime.year().month(.wide).day().weekday(.wide)))
-                    .font(.system(size: 13, weight: .semibold))
+                    .font(.appScaled(size: 13, weight: .semibold))
                 Text("\(items.count) 次提交 · 通过 \(items.count { $0.accepted })")
                     .font(.caption.monospacedDigit())
                     .foregroundStyle(.secondary)
                 Spacer(minLength: 8)
                 Button { selectedDay = nil } label: {
                     Image(systemName: "xmark")
-                        .font(.system(size: 10, weight: .semibold))
+                        .font(.appScaled(size: 10, weight: .semibold))
                         .foregroundStyle(.secondary)
                         .frame(width: 22, height: 22)
                         .contentShape(Circle())
@@ -1440,9 +1440,9 @@ private struct ProviderSettingsPage: View {
                 ProviderMark(assetName: provider.assetName, size: 26)
                 VStack(alignment: .leading, spacing: 2) {
                     Text(provider.name)
-                        .font(.system(size: 15, weight: .medium))
+                        .font(.appScaled(size: 15, weight: .medium))
                     Text(provider.model.isEmpty ? "未设置模型" : provider.model)
-                        .font(.system(size: 12))
+                        .font(.appScaled(size: 12))
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
                 }
@@ -1451,7 +1451,7 @@ private struct ProviderSettingsPage: View {
                     .fill(provider.isConfigured ? AppDesign.ColorToken.success : Color.secondary)
                     .frame(width: 7, height: 7)
                 Text("默认")
-                    .font(.system(size: 10, weight: .semibold))
+                    .font(.appScaled(size: 10, weight: .semibold))
                     .foregroundStyle(AppDesign.ColorToken.success)
                     .padding(.horizontal, 7)
                     .padding(.vertical, 2)
@@ -1572,7 +1572,7 @@ private struct ProviderSettingsPage: View {
                                     .frame(width: 30, height: 30)
                             } else {
                                 Image(systemName: "arrow.clockwise")
-                                    .font(.system(size: 13, weight: .medium))
+                                    .font(.appScaled(size: 13, weight: .medium))
                                     .frame(width: 30, height: 30)
                             }
                         }
@@ -1587,14 +1587,14 @@ private struct ProviderSettingsPage: View {
                     CardDivider()
                     SettingsRow("可用模型", subtitle: "从供应商实时获取") {
                         Text("\(model.availableModels.count) 个")
-                            .font(.system(size: 13).monospacedDigit())
+                            .font(.appScaled(size: 13).monospacedDigit())
                             .foregroundStyle(.secondary)
                     }
                 }
                 CardDivider()
                 SettingsRow("推理能力") {
                     Label("支持按任务覆盖", systemImage: "point.3.connected.trianglepath.dotted")
-                        .font(.system(size: 13))
+                        .font(.appScaled(size: 13))
                         .foregroundStyle(.secondary)
                 }
             }
@@ -1618,15 +1618,15 @@ private struct ProviderSettingsPage: View {
     private func routeRow(_ route: AITaskRoute) -> some View {
         HStack(spacing: 14) {
             Image(systemName: route.systemImage)
-                .font(.system(size: 15))
+                .font(.appScaled(size: 15))
                 .symbolRenderingMode(.hierarchical)
                 .foregroundStyle(.secondary)
                 .frame(width: 22)
             VStack(alignment: .leading, spacing: 2) {
                 Text(route.title)
-                    .font(.system(size: 15, weight: .medium))
+                    .font(.appScaled(size: 15, weight: .medium))
                 Text(route.subtitle)
-                    .font(.system(size: 12))
+                    .font(.appScaled(size: 12))
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
             }
@@ -1775,7 +1775,7 @@ private struct ContextSettingsPage: View {
                                 Task { await removeFact(fact.id) }
                             } label: {
                                 Image(systemName: "trash")
-                                    .font(.system(size: 11))
+                                    .font(.appScaled(size: 11))
                                     .foregroundStyle(.secondary)
                                     .frame(width: 24, height: 24)
                                     .contentShape(Rectangle())
@@ -1861,13 +1861,13 @@ private struct VideoSettingsPage: View {
                 } label: {
                     HStack(spacing: 12) {
                         Image(systemName: "clock.arrow.circlepath")
-                            .font(.system(size: 16, weight: .medium))
+                            .font(.appScaled(size: 16, weight: .medium))
                             .symbolRenderingMode(.hierarchical)
                             .foregroundStyle(.secondary)
                             .frame(width: 24)
                         VStack(alignment: .leading, spacing: 3) {
                             Text("本地播放历史")
-                                .font(.system(size: 14, weight: .medium))
+                                .font(.appScaled(size: 14, weight: .medium))
                             Text(dataStore.videoHistoryCount == 0
                                  ? "尚无记录"
                                  : "\(dataStore.videoHistoryCount) 条·点击视频在右侧浏览器播放")
@@ -1876,7 +1876,7 @@ private struct VideoSettingsPage: View {
                         }
                         Spacer()
                         Image(systemName: "chevron.right")
-                            .font(.system(size: 11, weight: .semibold))
+                            .font(.appScaled(size: 11, weight: .semibold))
                             .foregroundStyle(.tertiary)
                             .rotationEffect(.degrees(isHistoryExpanded ? 90 : 0))
                     }
@@ -1915,7 +1915,7 @@ private struct VideoSettingsPage: View {
                                 }
                                 Spacer()
                                 Image(systemName: "rectangle.righthalf.inset.filled.arrow.right")
-                                    .font(.system(size: 13))
+                                    .font(.appScaled(size: 13))
                                     .symbolRenderingMode(.hierarchical)
                                     .foregroundStyle(.tertiary)
                                     .frame(width: 28, height: 28)
@@ -2012,7 +2012,7 @@ private struct LearningSettingsPage: View {
         SettingsRow(title) {
             HStack(spacing: 10) {
                 Text("\(Int(value.wrappedValue)) 项")
-                    .font(.system(size: 13, weight: .medium))
+                    .font(.appScaled(size: 13, weight: .medium))
                     .monospacedDigit()
                     .foregroundStyle(.secondary)
                 HStack(spacing: 0) {
@@ -2034,7 +2034,7 @@ private struct LearningSettingsPage: View {
                     }
                     .disabled(value.wrappedValue >= range.upperBound)
                 }
-                .font(.system(size: 11, weight: .semibold))
+                .font(.appScaled(size: 11, weight: .semibold))
                 .foregroundStyle(.secondary)
                 .buttonStyle(.plain)
                 .glassCapsule()
@@ -2244,7 +2244,7 @@ private struct EmbeddedAccountLoginView: View {
             .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
         } else {
             Image(systemName: "person.crop.square")
-                .font(.system(size: 64))
+                .font(.appScaled(size: 64))
                 .foregroundStyle(.secondary)
         }
     }
@@ -2686,6 +2686,11 @@ private struct DataCacheSettingsPage: View {
 
 private struct AppearanceSettingsPage: View {
     @Bindable var dataStore: LegacyDataStore
+    private let metrics = InterfaceMetrics.shared
+
+    private var autoScaleText: String {
+        String(format: "%.2f×", metrics.displayScale)
+    }
     @State private var appearance = "system"
     @State private var emphasizeMotion = true
     @State private var status = ""
@@ -2699,6 +2704,22 @@ private struct AppearanceSettingsPage: View {
                         selection: $appearance
                     )
                     .frame(width: 230)
+                }
+                CardDivider()
+                // 界面已按屏幕自动缩放（口径见 `InterfaceMetrics.displayScale`），
+                // 这一档是在自动档之上再做相对调整，两者相乘。
+                SettingsRow(
+                    "界面字号",
+                    subtitle: "「跟随屏幕」按当前显示器算，这块屏上是 \(autoScaleText)"
+                ) {
+                    GlassSegmentedControl(
+                        options: InterfaceMetrics.FontScale.allCases.map { ($0.rawValue, $0.title) },
+                        selection: Binding(
+                            get: { metrics.fontScale.rawValue },
+                            set: { metrics.fontScale = InterfaceMetrics.FontScale(rawValue: $0) ?? .standard }
+                        )
+                    )
+                    .frame(width: 272)
                 }
                 CardDivider()
                 SettingsToggleRow("使用流畅的面板与符号动效", isOn: $emphasizeMotion)
@@ -2749,7 +2770,7 @@ private extension View {
 
     func settingsInputSurface() -> some View {
         textFieldStyle(.plain)
-            .font(.system(size: 13))
+            .font(.appScaled(size: 13))
             .padding(.horizontal, 12)
             .frame(height: 32)
             .settingsFieldChrome()
@@ -2765,10 +2786,10 @@ private struct SettingsMenuLabel: View {
                 .lineLimit(1)
             Spacer(minLength: 4)
             Image(systemName: "chevron.up.chevron.down")
-                .font(.system(size: 9, weight: .semibold))
+                .font(.appScaled(size: 9, weight: .semibold))
                 .foregroundStyle(.tertiary)
         }
-        .font(.system(size: 13))
+        .font(.appScaled(size: 13))
         .foregroundStyle(.primary)
         .padding(.horizontal, 12)
         .frame(height: 32)
@@ -2795,7 +2816,7 @@ private struct SettingsModelCombo: View {
         HStack(spacing: 0) {
             TextField("搜索或输入模型", text: $selection)
                 .textFieldStyle(.plain)
-                .font(.system(size: 13))
+                .font(.appScaled(size: 13))
                 .padding(.leading, 12)
                 .frame(maxWidth: .infinity)
 
@@ -2814,7 +2835,7 @@ private struct SettingsModelCombo: View {
                     }
                 } label: {
                     Image(systemName: "chevron.down")
-                        .font(.system(size: 11, weight: .semibold))
+                        .font(.appScaled(size: 11, weight: .semibold))
                         .foregroundStyle(.secondary)
                         .frame(width: 28, height: 30)
                         .contentShape(Rectangle())
@@ -2865,7 +2886,7 @@ private struct SettingsPillButtonStyle: ButtonStyle {
 
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
-            .font(.system(size: 13, weight: .medium))
+            .font(.appScaled(size: 13, weight: .medium))
             .foregroundStyle(tint ?? Color.primary)
             .padding(.horizontal, 14)
             .frame(height: 30)
@@ -2915,7 +2936,7 @@ private struct ProviderQuickLink: Identifiable {
 private struct ProviderLinkCapsuleStyle: ButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
-            .font(.system(size: 12, weight: .medium))
+            .font(.appScaled(size: 12, weight: .medium))
             .foregroundStyle(Color.accentColor)
             .padding(.horizontal, 11)
             .frame(height: 26)

--- a/native/Sources/LeetCodeAssistant/Views/StudyPlanWorkspaceView.swift
+++ b/native/Sources/LeetCodeAssistant/Views/StudyPlanWorkspaceView.swift
@@ -17,7 +17,12 @@ struct StudyPlanWorkspaceView: View {
                 calendarPane
                     // 左列也要吃满高度，否则它按内容取理想高度，
                     // 底边就和右侧时间线差出一截（两根圆角矩形对不齐）。
-                    .frame(minWidth: 344, maxWidth: 344, maxHeight: .infinity)
+                    // 下限比列表类高：日历是固定 7 列，压太窄日期会挤成一团。
+                    .paneListColumn(
+                        storageKey: "native.paneList.studyPlanCalendar",
+                        defaultWidth: 344,
+                        minWidth: 300
+                    )
                 timelinePane
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
@@ -287,7 +292,7 @@ struct StudyPlanWorkspaceView: View {
             if selectedTasks.isEmpty {
                 VStack(spacing: 8) {
                     Image(systemName: "calendar.badge.plus")
-                        .font(.system(size: 19, weight: .light))
+                        .font(.appScaled(size: 19, weight: .light))
                         .foregroundStyle(.tertiary)
                     Text("当天没有安排")
                         .font(.caption)
@@ -474,7 +479,7 @@ struct StudyPlanWorkspaceView: View {
                 try? dataStore.toggleStudyTask(task.id)
             } label: {
                 Image(systemName: task.isCompleted ? "checkmark.circle.fill" : "circle")
-                    .font(.system(size: 17))
+                    .font(.appScaled(size: 17))
                     .foregroundStyle(task.isCompleted ? AppDesign.ColorToken.success : priorityColor(task.priority))
             }
             .buttonStyle(.plain)
@@ -483,7 +488,7 @@ struct StudyPlanWorkspaceView: View {
             VStack(alignment: .leading, spacing: 7) {
                 HStack(spacing: 8) {
                     Text(task.title)
-                        .font(.system(size: 14, weight: .medium))
+                        .font(.appScaled(size: 14, weight: .medium))
                         .strikethrough(task.isCompleted)
                     Text(task.priority.title)
                         .font(.caption2.weight(.medium))
@@ -935,7 +940,7 @@ private struct AIStudyPlanPreviewRow: View {
             VStack(alignment: .leading, spacing: 5) {
                 HStack(spacing: 8) {
                     Text(task.title)
-                        .font(.system(size: 14, weight: .medium))
+                        .font(.appScaled(size: 14, weight: .medium))
                     if isReschedule {
                         Text("改期")
                             .font(.caption2.weight(.medium))

--- a/native/Sources/LeetCodeAssistant/Views/SyntaxHighlightedCodeView.swift
+++ b/native/Sources/LeetCodeAssistant/Views/SyntaxHighlightedCodeView.swift
@@ -20,7 +20,7 @@ struct SyntaxHighlightedCodeView: View {
             if showsHeader {
                 HStack(spacing: 8) {
                     Text(displayLanguage)
-                        .font(.system(size: 12, weight: .regular))
+                        .font(.appScaled(size: 12, weight: .regular))
                         .foregroundStyle(ConversationCodeBlockStyle.secondaryForeground)
                     Spacer()
                     Button {
@@ -33,7 +33,7 @@ struct SyntaxHighlightedCodeView: View {
                         }
                     } label: {
                         Image(systemName: copied ? "checkmark" : "doc.on.doc")
-                            .font(.system(size: 13, weight: .regular))
+                            .font(.appScaled(size: 13, weight: .regular))
                             .frame(
                                 width: ConversationCodeBlockStyle.copyControlSize,
                                 height: ConversationCodeBlockStyle.copyControlSize
@@ -54,7 +54,7 @@ struct SyntaxHighlightedCodeView: View {
             // 鼠标停在代码上滚动就推不动外层页面了。
             ScrollView(maxHeight == nil ? .horizontal : [.horizontal, .vertical]) {
                 highlightedText
-                    .font(.system(size: ConversationCodeBlockStyle.fontSize, design: .monospaced))
+                    .font(.appScaled(size: ConversationCodeBlockStyle.fontSize, design: .monospaced))
                     .lineSpacing(ConversationCodeBlockStyle.lineSpacing)
                     .textSelection(.enabled)
                     .fixedSize(horizontal: true, vertical: true)

--- a/native/Sources/LeetCodeAssistant/Views/UsageStatisticsView.swift
+++ b/native/Sources/LeetCodeAssistant/Views/UsageStatisticsView.swift
@@ -180,7 +180,7 @@ struct UsageStatisticsView: View {
                             ForEach(taskRows, id: \.0.id) { route, counters in
                                 HStack(spacing: 12) {
                                     Image(systemName: route.systemImage)
-                                        .font(.system(size: 13, weight: .semibold))
+                                        .font(.appScaled(size: 13, weight: .semibold))
                                         .foregroundStyle(.blue)
                                         .frame(width: 30, height: 30)
                                         .background(Color.blue.opacity(0.10), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
@@ -218,12 +218,12 @@ struct UsageStatisticsView: View {
     private func metricCard(_ title: String, _ value: Int?, icon: String, tint: Color) -> some View {
         VStack(alignment: .leading, spacing: 10) {
             Image(systemName: icon)
-                .font(.system(size: 13, weight: .semibold))
+                .font(.appScaled(size: 13, weight: .semibold))
                 .foregroundStyle(tint)
                 .frame(width: 28, height: 28)
                 .background(tint.opacity(0.12), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
             Text(value?.formatted() ?? "-")
-                .font(.system(size: 22, weight: .semibold).monospacedDigit())
+                .font(.appScaled(size: 22, weight: .semibold).monospacedDigit())
             Text(title)
                 .font(.caption)
                 .foregroundStyle(.secondary)
@@ -245,7 +245,7 @@ struct UsageStatisticsView: View {
     ) -> some View {
         HStack(spacing: 12) {
             Image(systemName: systemImage)
-                .font(.system(size: 13, weight: .semibold))
+                .font(.appScaled(size: 13, weight: .semibold))
                 .foregroundStyle(.indigo)
                 .frame(width: 30, height: 30)
                 .background(Color.indigo.opacity(0.10), in: RoundedRectangle(cornerRadius: 8, style: .continuous))

--- a/native/Sources/LeetCodeAssistant/Views/WindowTitlebarLayout.swift
+++ b/native/Sources/LeetCodeAssistant/Views/WindowTitlebarLayout.swift
@@ -76,9 +76,37 @@ final class WindowTrafficLightPositioner {
         window = nil
     }
 
+    /// 全屏动画进行中。退出全屏时 AppKit 在 `willExit` 就把 `.fullScreen` 从
+    /// styleMask 摘掉了，于是接下来那半秒的每一帧 resize 都会走进 `apply()`——
+    /// 我们逐帧强写红绿灯的 frame、还各排一次校验，等于和系统自己的动画抢同三颗按钮。
+    private var isTransitioning = false
+    /// 兜底计时的代次，用来忽略过期的那一发。
+    private var transitionGeneration = 0
+
+    private func beginTransition() {
+        isTransitioning = true
+        transitionGeneration &+= 1
+        let generation = transitionGeneration
+        // 兜底：`willEnter/willExit` 之后不一定有对应的 `did*`——动画被打断时
+        // AppKit 走的是 `windowDidFailTo…FullScreen` 代理方法，没有通知可收。
+        // 漏掉一次收尾，`isTransitioning` 就永远停在 true、红绿灯从此没人摆，
+        // 比动画抖一下严重得多。系统那段动画约半秒，2 秒足够宽。
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) { [weak self] in
+            guard let self, self.transitionGeneration == generation else { return }
+            self.endTransition()
+        }
+    }
+
+    private func endTransition() {
+        guard isTransitioning else { return }
+        isTransitioning = false
+        apply()
+    }
+
     /// 全屏由系统自己收起红绿灯，这里一律不碰；退出全屏时 `apply()` 会被再调一次。
     func apply() {
-        guard !isApplying, let window, !window.styleMask.contains(.fullScreen) else { return }
+        guard !isApplying, !isTransitioning else { return }
+        guard let window, !window.styleMask.contains(.fullScreen) else { return }
         guard let close = window.standardWindowButton(.closeButton),
               let titlebar = close.superview,
               let container = titlebar.superview,
@@ -166,10 +194,28 @@ final class WindowTrafficLightPositioner {
             })
         }
 
+        // 全屏动画期间停手，动画播完再排一次。
+        for (name, transitioning) in [
+            (NSWindow.willEnterFullScreenNotification, true),
+            (NSWindow.willExitFullScreenNotification, true),
+            (NSWindow.didEnterFullScreenNotification, false),
+            (NSWindow.didExitFullScreenNotification, false)
+        ] {
+            observers.append(NotificationCenter.default.addObserver(
+                forName: name,
+                object: window,
+                queue: nil
+            ) { [weak self] _ in
+                MainActor.assumeIsolated {
+                    guard let self else { return }
+                    if transitioning { self.beginTransition() } else { self.endTransition() }
+                }
+            })
+        }
+
         for name in [
             NSWindow.didResizeNotification,
             NSWindow.didBecomeKeyNotification,
-            NSWindow.didExitFullScreenNotification,
             // 兜底：窗口每轮事件处理结束都会发这条。进出设置页时 AppKit 可能
             // 直接换掉按钮视图而不是改 frame，那条路一个通知都不发。
             NSWindow.didUpdateNotification

--- a/native/Sources/LeetCodeAssistant/Views/WorkspaceSplitLayoutPolicy.swift
+++ b/native/Sources/LeetCodeAssistant/Views/WorkspaceSplitLayoutPolicy.swift
@@ -3,6 +3,9 @@ import CoreGraphics
 /// Pinned widths for the SwiftUI workspace columns.
 /// The shell is `NavigationSplitView` + `.inspector`; these numbers are the
 /// contract those modifiers must honor, not an AppKit split-view implementation.
+/// `@MainActor`：这些数现在跟着界面字号走（`AppDesign.Size` 里装文字的那一档），
+/// 而字号倍率是主线程上的可观察状态。
+@MainActor
 enum WorkspaceSplitLayoutPolicy {
     static var sidebarMin: CGFloat { AppDesign.Size.sidebarMin }
     static var sidebarIdeal: CGFloat { AppDesign.Size.sidebarIdeal }

--- a/native/Tests/LeetCodeAssistantTests/WorkspaceStateTests.swift
+++ b/native/Tests/LeetCodeAssistantTests/WorkspaceStateTests.swift
@@ -179,6 +179,52 @@ final class WorkspaceStateTests: XCTestCase {
         XCTAssertEqual(frame, CGRect(x: 0, y: 800 - band, width: 1_200, height: band))
     }
 
+    /// 全屏进出的那半秒里窗口宽度是连续变化的，断点会被一路扫过。
+    /// 中途那些临时状态一个都不该被看到——否则侧栏和上下文列会在动画里弹进弹出。
+    func testBreakpointsStayFrozenUntilTheFullScreenAnimationSettles() {
+        let (preferences, suiteName) = makePreferences()
+        defer { preferences.removePersistentDomain(forName: suiteName) }
+        let state = WorkspaceState(preferences: preferences)
+
+        // 从一个三列都放得下的宽度出发。
+        state.handleWindowWidth(1_900)
+        let sidebarBefore = state.compactSidebar
+        let contextBefore = state.compactContext
+
+        state.beginWindowTransition()
+        // 动画中途扫过所有断点：窄到连侧栏都该收起。
+        for width in stride(from: CGFloat(1_900), through: 600, by: -100) {
+            state.handleWindowWidth(width)
+        }
+        XCTAssertEqual(state.compactSidebar, sidebarBefore, "动画期间不许翻断点")
+        XCTAssertEqual(state.compactContext, contextBefore, "动画期间不许翻断点")
+        XCTAssertEqual(state.windowWidth, 600, "宽度本身照记，只是先不结算")
+
+        // 落定：按最终宽度一次性算完。
+        state.endWindowTransition()
+        XCTAssertTrue(state.compactSidebar, "600pt 放不下侧栏，落定后应当收起")
+        XCTAssertTrue(state.compactContext)
+    }
+
+    /// `endWindowTransition` 要用动画期间记下的最后一个宽度结算，
+    /// 而不是进入动画前的那个——否则全屏后布局还按窗口态的宽度排。
+    func testTransitionSettlesOnTheFinalWidth() {
+        let (preferences, suiteName) = makePreferences()
+        defer { preferences.removePersistentDomain(forName: suiteName) }
+        let state = WorkspaceState(preferences: preferences)
+
+        state.handleWindowWidth(700)
+        XCTAssertTrue(state.compactSidebar)
+
+        state.beginWindowTransition()
+        state.handleWindowWidth(1_920)
+        XCTAssertTrue(state.compactSidebar, "动画期间维持原样")
+
+        state.endWindowTransition()
+        XCTAssertFalse(state.compactSidebar, "全屏落定后该按 1920 排")
+        XCTAssertEqual(state.windowWidth, 1_920)
+    }
+
     @MainActor
     func testColumnWidthSettersClampToPinnedRanges() {
         let (preferences, suiteName) = makePreferences()

--- a/native/Tests/LeetCodeAssistantTests/WorkspaceStateTests.swift
+++ b/native/Tests/LeetCodeAssistantTests/WorkspaceStateTests.swift
@@ -1,6 +1,9 @@
 import XCTest
 @testable import LeetCodeAssistant
 
+// 布局尺寸现在跟着界面字号走（`AppDesign.Size` 里装文字的那一档是主线程可观察状态），
+// 所以这些断言也必须在主线程上跑。
+@MainActor
 final class WorkspaceStateTests: XCTestCase {
     func testConversationTitleUsesTheSameLeadingInsetAsTheComposer() {
         // 1200 宽：正文列 1100，两边各让 50。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "leetcode-ai-helper",
-  "version": "2.0.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "leetcode-ai-helper",
-      "version": "2.0.0",
+      "version": "2.2.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leetlens",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "A LeetCode practice client for learning algorithms. AI turns questions, chats, and submissions into a knowledge map and a review queue.",
   "private": true,
   "author": "huaxx-lab",


### PR DESCRIPTION
## 起因

大屏（外接 1920×1080 @1x）上界面「字小、内容缩成中间一座孤岛」，以及全屏进出时会跳好几下。

查下来根因有三条：

1. **全 App 字号都是写死的 pt** —— `Font.system(size:)` 在 macOS 上不随任何东西缩放
2. **不少列宽上下界相同**（`minWidth: 268, maxWidth: 268`）—— 等于焊死，窗口拉宽它纹丝不动
3. **全屏动画那半秒里断点被一路扫过** —— 列在动画中途弹进弹出

另外发现 Electron 1.x 客户端本来就有按屏幕自动缩放（`src/platform/display-profile.js`，CSS 里 `--display-scale` 用了 264 处），原生 2.0 重写时把这套丢了。

## 改动

### 界面字号（新增 `Design/InterfaceMetrics.swift`）

设置 ▸ 外观 ▸ 界面字号：紧凑 0.92 / 标准 1.0 / 较大 1.12 / 跟随屏幕。整套 `AppDesign.Typography` 与新的 `Font.appScaled(size:)` 都乘这一档，View 层 118 处裸 `.font(.system(size:))` 一并接进来。

「跟随屏幕」的曲线照搬 `display-profile.js`，但封顶从 1.5 收到 1.25 —— 原生版字体阶梯基准更大，1.38× 明显过头。**默认是「标准」= ×1.0，开箱观感不变。**

### 尺寸阶梯拆成两类（`DesignTokens.swift`）

- **窗口 chrome**（`columnHeader` / 红绿灯内缩 / `toolbarControl`）保持死数：要和系统画的东西对齐，跟着字号变会错开红绿灯与列头的中线
- **装文字的**（列宽、版心、行高、输入框高）跟着倍率走 —— 只放大字不放大列，侧栏标题只会截得更狠
- `WorkspaceState.reclampColumnWidths()`：倍率变了要把存档里的列宽重新夹一次

### 解冻写死的列（新增 `Views/PaneListColumn.swift`）

复用第一列的 `ColumnResizeHandle`，宽度按页存档：

| 位置 | 之前 | 现在 |
|---|---|---|
| 学习计划日历 | 344 焊死 | 可拖 300–520 |
| 算法模板列表 | 268 焊死 | 可拖 240–520 |
| 题解弹窗列表 | 248 焊死 | 可拖 200–380 |
| 学习题库 / 今日复习列表 | 上限 360 / 312 | 520 |

### 版心

- 学习洞察 1120 → 1600（新 `dashboardColumnMaximum`）；指标卡按可用宽度排 4/2/1 列，两张主卡窄于 900pt 时叠成一列
- 学习题库 / 复习详情 760 → `contentColumnMaximum`
- 设置页 740 与 980 两个版心统一 —— 原来账户页的标题和卡片左缘对不齐
- 学习题库侧栏页头补 `maxWidth: .infinity`：HStack 没被撑满时 `Spacer` 推不动东西，「全部」胶囊和计数一起飘到侧栏正中

### 全屏进出

- `will*` 冻结断点、`did*` 按最终宽度一次性结算，中途扫过的临时状态不再被看到
- `WindowTitlebarLayout` 在动画期间停手：退出全屏时 AppKit 在 `willExit` 就摘掉了 `.fullScreen`，之前每一帧 resize 都在逐帧强写红绿灯 frame，等于和系统动画抢同一批视图
- 带 2 秒兜底：动画被打断时 AppKit 走的是 `windowDidFailTo…FullScreen` 代理方法，没有通知可收，漏掉收尾红绿灯就永远没人摆

## 验证

- `swift build` 通过；116 个 swift-testing 用例全过（两个失败的是要连远程服务的集成测试：SSH 补全隧道、pgvector，改动前就在失败）
- 新增两条断点冻结的单元测试
- 实机截图确认：默认档观感与改动前一致；「跟随屏幕」档下侧栏 218 → 273，原先被截断的会话标题全部放得下
- ⚠️ 全屏进出的**动画平滑度本身没有在屏幕上验证**：这台机器没给终端辅助功能权限，驱动不了应用切换全屏，逻辑由单元测试覆盖

🤖 Generated with [Claude Code](https://claude.com/claude-code)