### PR TITLE
三列开合动画重做、刷题页分栏换原生、侧栏收纳每日简报

### DIFF
--- a/native/App/Info.plist
+++ b/native/App/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.2.0</string>
+	<string>2.3.0</string>
 	<key>CFBundleVersion</key>
-	<string>2</string>
+	<string>3</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>15.0</string>
 	<key>NSHighResolutionCapable</key>

--- a/native/Sources/LeetCodeAssistant/Design/DesignTokens.swift
+++ b/native/Sources/LeetCodeAssistant/Design/DesignTokens.swift
@@ -137,7 +137,10 @@ enum AppDesign {
     enum Motion {
         static let panel = Animation.spring(response: 0.38, dampingFraction: 0.88, blendDuration: 0.08)
         /// 分栏显隐使用无回弹的短过渡，既不僵硬，也不会让重型内容来回越界重排。
-        static let panelTransition = Animation.easeInOut(duration: 0.22)
+        /// 三列开合的时长。内容宽度现在跟着裁剪框一起补间（"一个平面"），
+        /// 这一段里网页要逐帧重排，帧数越少越稳，所以从 0.22 收到 0.18。
+        static let panelTransitionDuration: Double = 0.18
+        static let panelTransition = Animation.easeInOut(duration: panelTransitionDuration)
         static let selection = Animation.snappy(duration: 0.22, extraBounce: 0.03)
         static let subtle = Animation.easeOut(duration: 0.16)
         static let fade = Animation.easeInOut(duration: 0.18)

--- a/native/Sources/LeetCodeAssistant/Models/LegacyDataStore.swift
+++ b/native/Sources/LeetCodeAssistant/Models/LegacyDataStore.swift
@@ -67,6 +67,12 @@ struct ConversationSummary: Identifiable, Hashable, Sendable {
     var lastChatUsage = ConversationUsage()
     var isPinned = false
 
+    /// 是不是每日学习简报。按简报那条消息的 id 前缀判定，不看标题——
+    /// 标题会被 AI 改写，改完就认不出来了。
+    var isDailyBrief: Bool {
+        messages.contains { $0.id.hasPrefix(LearningAgentTools.dailyBriefMessagePrefix) }
+    }
+
     var revision: ConversationRevision {
         ConversationRevision(
             updatedAtMilliseconds: Int64((updatedAt.timeIntervalSince1970 * 1_000).rounded()),

--- a/native/Sources/LeetCodeAssistant/Services/LearningAgentTools.swift
+++ b/native/Sources/LeetCodeAssistant/Services/LearningAgentTools.swift
@@ -256,11 +256,15 @@ enum LearningAgentTools {
         return DailyBrief(
             dayKey: dayKey,
             title: "今日学习简报 · \(month)月\(day)日",
-            messageID: "m_daily_brief_\(dayKey)",
+            messageID: dailyBriefMessagePrefix + dayKey,
             content: "## 今日学习简报\n\n" + paragraphs.joined(separator: "\n\n"),
             runs: [planRun, weakRun]
         )
     }
+
+    /// 每日简报那条消息的 id 前缀。侧栏靠它把简报会话认出来——
+    /// 不能靠标题前缀，标题会被 AI 改写，一改就认不出来了。
+    static let dailyBriefMessagePrefix = "m_daily_brief_"
 
     // MARK: - 执行
 

--- a/native/Sources/LeetCodeAssistant/Views/GlobalSidebarView.swift
+++ b/native/Sources/LeetCodeAssistant/Views/GlobalSidebarView.swift
@@ -5,6 +5,7 @@ struct GlobalSidebarView: View {
     @Bindable var workspace: WorkspaceState
     @Bindable var dataStore: LegacyDataStore
     @Environment(\.colorScheme) private var colorScheme
+    // 简报**不在**默认展开集合里：它一天长一条，展开着会把真正的会话挤到看不见。
     @State private var expandedGroups: Set<SidebarGroup> = [.learning, .conversations, .plans]
     @State private var pendingConversationDeletion: ConversationSummary?
     /// 账户行那个 `Menu` 必须拿到显式宽度，见 `accountMenu` 的注释。
@@ -36,8 +37,23 @@ struct GlobalSidebarView: View {
 
                     groupHeader(.conversations, title: "最近会话", systemImage: "clock")
                     if expandedGroups.contains(.conversations) {
-                        ForEach(dataStore.conversations) { conversation in
+                        ForEach(chatConversations) { conversation in
                             conversationRow(conversation)
+                        }
+                    }
+
+                    if !dailyBriefs.isEmpty {
+                        groupHeader(
+                            .briefings,
+                            title: "学习简报",
+                            systemImage: "sun.max",
+                            badge: "\(dailyBriefs.count)"
+                        )
+                        if expandedGroups.contains(.briefings) {
+                            ForEach(dailyBriefs) { conversation in
+                                // 组名已经写着「学习简报」，行里只留日期，不再重复一遍标题。
+                                conversationRow(conversation, label: briefDateLabel(conversation))
+                            }
                         }
                     }
 
@@ -164,7 +180,8 @@ struct GlobalSidebarView: View {
     private func groupHeader(
         _ group: SidebarGroup,
         title: String,
-        systemImage: String
+        systemImage: String,
+        badge: String? = nil
     ) -> some View {
         Button {
             withAnimation(.easeOut(duration: 0.14)) {
@@ -180,6 +197,12 @@ struct GlobalSidebarView: View {
                 Text(title)
                     .font(AppDesign.Typography.bodyEmphasis)
                 Spacer(minLength: 4)
+                // 收起时也看得见有多少条，省得为了数一眼再展开。
+                if let badge {
+                    Text(badge)
+                        .font(AppDesign.Typography.micro.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                }
             }
             .frame(maxWidth: .infinity, minHeight: AppDesign.Size.compactRow, alignment: .leading)
             .padding(.horizontal, AppDesign.Spacing.xs)
@@ -190,14 +213,32 @@ struct GlobalSidebarView: View {
         .padding(.top, 5)
     }
 
-    private func conversationRow(_ conversation: ConversationSummary) -> some View {
+    /// 简报和普通会话分开列：简报一天一条，混在「最近会话」里会把真正聊过的内容顶下去。
+    private var dailyBriefs: [ConversationSummary] {
+        dataStore.conversations.filter(\.isDailyBrief)
+    }
+
+    private var chatConversations: [ConversationSummary] {
+        dataStore.conversations.filter { !$0.isDailyBrief }
+    }
+
+    /// 「今日学习简报 · 9月7日」→「9月7日」。分隔符找不到就原样返回（标题被改写过）。
+    private func briefDateLabel(_ conversation: ConversationSummary) -> String {
+        guard let range = conversation.title.range(of: " · ") else { return conversation.title }
+        return String(conversation.title[range.upperBound...])
+    }
+
+    private func conversationRow(
+        _ conversation: ConversationSummary,
+        label: String? = nil
+    ) -> some View {
         Button {
             withAnimation(AppDesign.Motion.selection) {
                 workspace.selectedConversationID = conversation.id
                 workspace.selectedSection = .conversation
             }
         } label: {
-            FadingSidebarText(conversation.title)
+            FadingSidebarText(label ?? conversation.title)
                 .font(AppDesign.Typography.body)
                 .frame(maxWidth: .infinity, minHeight: 32, alignment: .leading)
                 .padding(.leading, Self.indentedInset)
@@ -458,6 +499,7 @@ private final class RemoteAvatarCache {
 private enum SidebarGroup: Hashable {
     case learning
     case conversations
+    case briefings
     case plans
 }
 

--- a/native/Sources/LeetCodeAssistant/Views/LearningCenterViews.swift
+++ b/native/Sources/LeetCodeAssistant/Views/LearningCenterViews.swift
@@ -49,7 +49,8 @@ struct LearningLibraryWorkspaceView: View {
     }
 
     var body: some View {
-        HSplitView {
+        // 不用 HSplitView：它是 NSSplitView，三列开合时列宽在补间，它会逐帧重排窗格。
+        HStack(spacing: 0) {
             VStack(spacing: 0) {
                 HStack(spacing: 8) {
                     Menu {
@@ -158,11 +159,7 @@ struct LearningLibraryWorkspaceView: View {
                     }
                 }
             }
-            .frame(
-                minWidth: AppDesign.Size.paneListMin,
-                idealWidth: 300,
-                maxWidth: AppDesign.Size.paneListMax
-            )
+            .paneListColumn(storageKey: "native.paneList.library", defaultWidth: 300)
             .background(AppDesign.ColorToken.canvas)
 
             if let record = selectedRecord {
@@ -170,6 +167,7 @@ struct LearningLibraryWorkspaceView: View {
                     .frame(minWidth: 500, maxWidth: .infinity, maxHeight: .infinity)
             } else {
                 ContentUnavailableView("没有符合条件的学习项", systemImage: "books.vertical")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
         }
         .onAppear {

--- a/native/Sources/LeetCodeAssistant/Views/LearningWorkspaces.swift
+++ b/native/Sources/LeetCodeAssistant/Views/LearningWorkspaces.swift
@@ -41,16 +41,13 @@ struct ReviewWorkspaceView: View {
     }
 
     var body: some View {
-        HSplitView {
+        // 不用 HSplitView：它是 NSSplitView，三列开合时列宽在补间，它会逐帧重排窗格。
+        HStack(spacing: 0) {
             reviewQueue
-                .frame(
-                    minWidth: AppDesign.Size.paneListMin,
-                    idealWidth: 276,
-                    maxWidth: AppDesign.Size.paneListMax
-                )
+                .paneListColumn(storageKey: "native.paneList.reviewQueue", defaultWidth: 276)
 
             reviewDetail
-                .frame(minWidth: 540, maxWidth: .infinity, maxHeight: .infinity)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
         .onAppear {
             adoptExternalSelection()

--- a/native/Sources/LeetCodeAssistant/Views/LeetCodeWorkspaceView.swift
+++ b/native/Sources/LeetCodeAssistant/Views/LeetCodeWorkspaceView.swift
@@ -619,7 +619,13 @@ struct LeetCodeWorkspaceView: View {
     }
 
     private var questionWorkspace: some View {
-        HSplitView {
+        // 不用 HSplitView：它是 NSSplitView，三列开合时列宽在补间，
+        // 它会逐帧重新分配窗格、里面的 WKWebView 每帧重排，画面上窗格互相错位。
+        ProportionalSplit(
+            storageKey: "native.leetcode.problemFraction",
+            minLeading: 360,
+            minTrailing: 380
+        ) {
             Group {
                 if let workspace = selectedWorkspace, !workspace.htmlContent.isEmpty {
                     LeetCodeProblemWebView(html: workspace.htmlContent)
@@ -652,8 +658,7 @@ struct LeetCodeWorkspaceView: View {
                     )
                 }
             }
-            .frame(minWidth: 360, idealWidth: 560)
-            // 两条都是**浮层**，不参与 HSplitView 的布局——力扣官网那条也是浮在题面窗格底部的胶囊。
+            // 两条都是**浮层**，不参与分栏布局——力扣官网那条也是浮在题面窗格底部的胶囊。
             // 之前以为要把这一栏拆成上下结构才能加，是我想复杂了：题面照旧铺满，浮层压在它上面。
             .overlay(alignment: .bottom) { problemActionOverlay }
             .task(id: selectedQuestionSlug) { await loadQuestionMeta() }
@@ -669,10 +674,10 @@ struct LeetCodeWorkspaceView: View {
                 }
             }
 
+        } trailing: {
             Group {
                 if isSolving { editorPane } else { submissionDetailPane }
             }
-            .frame(minWidth: 380, idealWidth: 560)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }

--- a/native/Sources/LeetCodeAssistant/Views/PaneListColumn.swift
+++ b/native/Sources/LeetCodeAssistant/Views/PaneListColumn.swift
@@ -64,3 +64,66 @@ extension View {
         )
     }
 }
+
+/// 两栏等价内容的比例分栏（刷题页的题面 / 代码与提交）。
+///
+/// **为什么不用 `HSplitView`**：它是 `NSSplitView`，不吃 SwiftUI 动画。三列开合时
+/// 外层列宽正在补间，它每一帧都按新宽度重新分配窗格、里面的 WKWebView 每帧重排一次，
+/// 画面上就是窗格互相错位、题面从左边被裁掉一截、代码行号漏到最左边。
+///
+/// **存比例不存绝对宽度**：列被拉宽或收窄时两栏按同一个比例一起缩放，看着才是一个整体；
+/// 存绝对宽度的话，列一变宽全部多出来的空间都堆给右栏。
+struct ProportionalSplit<Leading: View, Trailing: View>: View {
+    let storageKey: String
+    var defaultFraction: Double = 0.5
+    var minLeading: CGFloat = 360
+    var minTrailing: CGFloat = 380
+    @ViewBuilder var leading: () -> Leading
+    @ViewBuilder var trailing: () -> Trailing
+
+    @State private var fraction: Double?
+
+    var body: some View {
+        GeometryReader { proxy in
+            let total = proxy.size.width
+            let width = leadingWidth(total: total)
+            HStack(spacing: 0) {
+                leading()
+                    .frame(width: width)
+                    .frame(maxHeight: .infinity)
+
+                Rectangle()
+                    .fill(AppDesign.ColorToken.separator)
+                    .frame(width: 1)
+                    .frame(maxHeight: .infinity)
+                    .overlay {
+                        ColumnResizeHandle(
+                            width: width,
+                            range: minLeading...max(minLeading, total - minTrailing),
+                            growsOnDragRight: true
+                        ) { newValue in
+                            guard total > 0 else { return }
+                            // 夹在 10%–90%：拖到贴边之后列就再也拉不回来了。
+                            let next = min(max(Double(newValue / total), 0.1), 0.9)
+                            fraction = next
+                            UserDefaults.standard.set(next, forKey: storageKey)
+                        }
+                    }
+
+                trailing()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+    }
+
+    /// 比例换算成宽度后仍要夹一次最小宽：窗口很窄时按比例算出来的值会小于任一栏的下限。
+    private func leadingWidth(total: CGFloat) -> CGFloat {
+        let upper = max(minLeading, total - minTrailing)
+        return min(max(total * (fraction ?? storedFraction), minLeading), upper)
+    }
+
+    private var storedFraction: Double {
+        let stored = UserDefaults.standard.double(forKey: storageKey)
+        return stored > 0 ? stored : defaultFraction
+    }
+}

--- a/native/Sources/LeetCodeAssistant/Views/WorkspaceColumnShell.swift
+++ b/native/Sources/LeetCodeAssistant/Views/WorkspaceColumnShell.swift
@@ -3,14 +3,23 @@ import SwiftUI
 
 /// SwiftUI three-column shell. Not `NavigationSplitView`, not `NSSplitView`.
 ///
-/// 每一列都是「外层裁剪框 + 内层固定宽度内容」两层：
-/// **外层**的宽度参与动画（展开/收起时补间），**内层**一步到位落到目标宽度。
-/// 这是当初把动画整个关掉的那个坑的正解——中间列和第三列里装的是 WKWebView，
-/// 让它跟着补间宽度走等于每帧重排一次网页，滚动位置乱跳、播放中的视频还会卡住；
-/// 现在网页只在动画开始时排一次，动画本身只是把它裁出来/裁回去。
+/// 每一列都是「外层裁剪框 + 内层内容」两层，**动画期间两层同宽**。
 ///
-/// 收起的列不卸载、也不把内容宽度压成 0（那等于再重排两次），
-/// 而是保持最后一个正宽度，外层裁到 0——第三列放大再还原时，会话页面原样还在。
+/// 曾经的做法是内层一步到位、只让外层补间，为的是别让 WKWebView 逐帧重排。
+/// 代价是看着不像一个整体：点收起，中间列瞬间就是最终宽度了，侧栏才慢慢滑走，
+/// 像侧栏盖在中间列上面。所以改回锁步——中间列展开与侧栏收起同时发生。
+///
+/// 逐帧重排的老问题用另外两招压住：动画从 0.22s 收到 0.18s；
+/// 收起到很窄时内容宽度不再继续跟到 0，而是停在 `collapsedContentFloor`，
+/// 避免把 0 宽度交给 WKWebView（那一下会把滚动位置和播放中的视频弄丢）。
+///
+/// 动画结束后，收起的列把内容宽度还原到最后一个正宽度并停在那儿（外层仍裁到 0），
+/// 这样第三列放大再还原时，会话页面原样还在。
+/// 收起过程中内容宽度的下限。再窄就不跟了——0 宽度的 WKWebView 重排会丢滚动位置，
+/// 而这一段本来也几乎看不见（外层已经裁到比它还窄）。
+/// 放在类型外：泛型类型里不能有 static 存储属性。
+private let workspaceCollapsedContentFloor: CGFloat = 200
+
 struct WorkspaceColumnShell<Sidebar: View, Detail: View, Inspector: View>: View {
     var sidebarVisible: Bool
     var inspectorVisible: Bool
@@ -24,6 +33,10 @@ struct WorkspaceColumnShell<Sidebar: View, Detail: View, Inspector: View>: View 
     @ViewBuilder var inspector: () -> Inspector
 
     @State private var restingWidths = WorkspaceColumnWidths(sidebar: 0, detail: 0, inspector: 0)
+    /// 开合动画是否正在进行。只有这段时间内容宽度才跟着裁剪框走。
+    @State private var isAnimatingColumns = false
+    @State private var settleTask: Task<Void, Never>?
+
 
     var body: some View {
         GeometryReader { proxy in
@@ -35,7 +48,7 @@ struct WorkspaceColumnShell<Sidebar: View, Detail: View, Inspector: View>: View 
                 inspectorExpanded: inspectorExpanded,
                 inspectorWidth: inspectorWidth
             )
-            let content = widths.contentWidths(fallingBackTo: restingWidths)
+            let content = contentWidths(for: widths)
 
             HStack(spacing: 0) {
                 column(visible: widths.sidebar, content: content.sidebar, reveal: .trailing) {
@@ -109,9 +122,37 @@ struct WorkspaceColumnShell<Sidebar: View, Detail: View, Inspector: View>: View 
             // 挂上动画就会跟不上指针——那时要的是一比一跟手。
             .animation(AppDesign.Motion.panelTransition, value: transitions)
             .onChange(of: widths) { _, new in restingWidths = new.restingWidths(previous: restingWidths) }
+            .onChange(of: transitions) { _, _ in beginColumnAnimation() }
             .onAppear { restingWidths = widths.restingWidths(previous: restingWidths) }
+            .onDisappear { settleTask?.cancel() }
         }
         .background(AppDesign.ColorToken.canvas)
+    }
+
+    /// 动画期间内容跟着裁剪框走（锁步）；静止时收起的列回落到最后一个正宽度。
+    private func contentWidths(for widths: WorkspaceColumnWidths) -> WorkspaceColumnWidths {
+        guard isAnimatingColumns else { return widths.contentWidths(fallingBackTo: restingWidths) }
+        let floor = workspaceCollapsedContentFloor
+        return WorkspaceColumnWidths(
+            sidebar: max(widths.sidebar, min(floor, restingWidths.sidebar)),
+            detail: max(widths.detail, min(floor, restingWidths.detail)),
+            inspector: max(widths.inspector, min(floor, restingWidths.inspector))
+        )
+    }
+
+    /// 开合开始时进入锁步，一个动画时长之后退出。
+    /// 退出这一下会把收起的列的内容宽度从 floor 还原到 resting——必须不带动画，
+    /// 否则动画刚停又起一段。
+    private func beginColumnAnimation() {
+        isAnimatingColumns = true
+        settleTask?.cancel()
+        settleTask = Task { @MainActor in
+            try? await Task.sleep(for: .seconds(AppDesign.Motion.panelTransitionDuration))
+            guard !Task.isCancelled else { return }
+            var transaction = Transaction(animation: nil)
+            transaction.disablesAnimations = true
+            withTransaction(transaction) { isAnimatingColumns = false }
+        }
     }
 
     private var transitions: WorkspaceColumnTransitions {
@@ -134,7 +175,6 @@ struct WorkspaceColumnShell<Sidebar: View, Detail: View, Inspector: View>: View 
         body()
             .frame(width: content)
             .frame(maxHeight: .infinity)
-            .animation(nil, value: content)
             .frame(width: visible, alignment: reveal)
             .clipped()
             // `.clipped()` 只裁画面不裁命中：不加这一句，收起的列还会在原地吃掉点击。

--- a/native/scripts/build-release-app.sh
+++ b/native/scripts/build-release-app.sh
@@ -86,6 +86,10 @@ codesign --verify --deep --strict ${STAGE_APP}
 
 rm -rf ${DIST_DIR}
 mkdir -p ${DIST_DIR}
+# 让 Spotlight 别索引构建产物。dist/ 里的 .app 和 /Applications 里装的那份同名、
+# 同 bundle id，被索引之后 Launchpad 与聚焦里就会并排出现两个 LeetLens，
+# 看着像装了两遍——其实一个是安装，一个只是构建输出。
+touch ${DIST_DIR}/.metadata_never_index
 APP_PATH=${DIST_DIR}/${APP_NAME}.app
 ditto --norsrc --noextattr ${STAGE_APP} ${APP_PATH}
 xattr -cr ${APP_PATH}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "leetcode-ai-helper",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "leetcode-ai-helper",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leetlens",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "A LeetCode practice client for learning algorithms. AI turns questions, chats, and submissions into a knowledge map and a review queue.",
   "private": true,
   "author": "huaxx-lab",


### PR DESCRIPTION
## 开合动画：看着不像一个整体

列壳原来是「外层裁剪框补间、内层内容一步到位」，于是点收起时中间列瞬间就是最终宽度，侧栏才慢慢滑走，像侧栏盖在中间列上面。改成**锁步**：内容宽度和裁剪框一起补间，中间列展开与侧栏收起同时发生。右侧栏走同一套代码。

当初做成两层是为了避免 WKWebView 逐帧重排（滚动乱跳、视频卡住），改回锁步后用两道保险压住：

- 动画时长 0.22s → 0.18s
- 收起到很窄时内容宽度停在 200pt 不再跟到 0（0 宽度的 WKWebView 重排会丢滚动位置）
- 动画结束由 settle 状态机把收起列的内容宽度无动画还原到最后一个正宽度

## 刷题页：窗格错位、题面被从左边裁掉

根因是 `HSplitView`（`NSSplitView`），它不吃 SwiftUI 动画 —— 外层列宽在补间时，它每帧按新宽度重新分配窗格、里面的 WKWebView 每帧重排。

- 刷题页换成新的 `ProportionalSplit`：存**比例**不存绝对宽度，列变宽时两栏按同一比例一起缩放
- 学习题库、今日复习换成 `HStack` + `paneListColumn`
- 全项目已无 `HSplitView`

## 侧栏：每日简报淹没了最近会话

简报一天生成一个会话，十来天之后「最近会话」里全是它。

- 新增「学习简报」分组，默认收起，组标题右侧显示条数
- 「最近会话」只留普通对话
- 展开后每行只显示日期，组名已经写着「学习简报」
- 识别按消息 id 前缀，不看标题（标题会被 AI 改写）

## 其它

- 发布产物目录加 `.metadata_never_index`：`dist/` 里的 .app 和 `/Applications` 里那份同名同 bundle id，被索引后 Launchpad 里会出现两个 LeetLens
- 版本号 2.2.0 → 2.3.0

## 验证

- `swift build` 通过；116 个 swift-testing 用例全过（3 个失败的是要连远程服务的集成测试：Redis、SSH 隧道、pgvector，改动前就在失败）
- 实机截图确认侧栏分组生效、各页面渲染正常
- ⚠️ **动画观感本身没有在屏幕上验证**：抓帧的老 API 在 macOS 15 已废弃，`screencapture` 单帧太慢，抓不到 0.18s 里的中间帧。改动按根因做，手感需人工确认

🤖 Generated with [Claude Code](https://claude.com/claude-code)